### PR TITLE
equals should not be mandatory in query parameters

### DIFF
--- a/NanoHTTPD.java
+++ b/NanoHTTPD.java
@@ -744,6 +744,8 @@ public class NanoHTTPD
 				if ( sep >= 0 )
 					p.put( decodePercent( e.substring( 0, sep )).trim(),
 						   decodePercent( e.substring( sep+1 )));
+				else
+					p.put( decodePercent( e ).trim(), "" );
 			}
 		}
 


### PR DESCRIPTION
> Before this patch query parameter keys that do not contain an equals are
> ignored, i.e. ?key1=one&key2&key3=three would result in key2 not being
> present in the parameters Properties. this patch allows such keys to be
> added with a default empty string.

P.S. Many thanks for your work on this server, and your coding standards/style are brill!
