### PR TITLE
Support for HTTPS

### DIFF
--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -137,13 +137,15 @@ public abstract class NanoHTTPD {
      */
     public void start() throws IOException {
          if (sslServerSocketFactory != null) {
-            SSLServerSocket ss = (SSLServerSocket) sslServerSocketFactory.createServerSocket(myPort);
+            SSLServerSocket ss = (SSLServerSocket) sslServerSocketFactory.createServerSocket();
             ss.setNeedClientAuth(false);
             myServerSocket = ss;
         } else {
             myServerSocket = new ServerSocket();
-            myServerSocket.bind((hostname != null) ? new InetSocketAddress(hostname, myPort) : new InetSocketAddress(myPort));
         }
+        
+        myServerSocket.bind((hostname != null) ? new InetSocketAddress(hostname, myPort) : new InetSocketAddress(myPort));
+
         myThread = new Thread(new Runnable() {
             @Override
             public void run() {


### PR DESCRIPTION
Optional call to run server using HTTPS instead of plaintext by calling makeSecure() before start()
