### PR TITLE
Add a Content-Length header even if the response has no content data.

### DIFF
--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -539,11 +539,9 @@ public abstract class NanoHTTPD {
                     }
                 }
 
-                int pending = data != null ? data.available() : -1; // This is to support partial sends, see serveFile()
-                if (pending > 0) {
-                    pw.print("Connection: keep-alive\r\n");
-                    pw.print("Content-Length: "+pending+"\r\n");
-                }
+                int pending = data != null ? data.available() : 0; // This is to support partial sends, see serveFile()
+                pw.print("Connection: keep-alive\r\n");
+                pw.print("Content-Length: "+pending+"\r\n");
 
                 pw.print("\r\n");
                 pw.flush();


### PR DESCRIPTION
I ran into the following issue while using NanoHTTPD in my project:
I serve files and generated content with NanoHTTPD. It happens that the Response content is empty : either an empty string or a FileInputStream on an empty file.

In these cases, the request stayed 'pending' in the browser. To my understanding this is due to the fact that neither the browser nor NanoHTTPD closes the socket and there is no Content-Length header in the response. The browser doesn't know how much data it has to read and waits for it as the socket is not closed.

Adding a "Content-Length: 0" header solves the problem.

You'll find here a pull request with a proposed solution.

TIA.
