### PR TITLE
Added constant socket read timeout

### DIFF
--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -53,6 +53,12 @@ import java.util.*;
  */
 public abstract class NanoHTTPD {
     /**
+     * Maximum time to wait on Socket.getInputStream().read() (in milliseconds)
+     * This is required as the Keep-Alive HTTP connections would otherwise
+     * block the socket reading thread forever (or as long the browser is open).
+     */
+    public static final int SOCKET_READ_TIMEOUT = 5000;
+    /**
      * Common mime type for dynamic content: plain text
      */
     public static final String MIME_PLAINTEXT = "text/plain";
@@ -136,6 +142,7 @@ public abstract class NanoHTTPD {
                 do {
                     try {
                         final Socket finalAccept = myServerSocket.accept();
+                        finalAccept.setSoTimeout(SOCKET_READ_TIMEOUT);
                         final InputStream inputStream = finalAccept.getInputStream();
                         if (inputStream == null) {
                             safeClose(finalAccept);


### PR DESCRIPTION
I encountered the problem that the server would not shutdown as long as a webbrowser, that accessed the server, still ran. This is because the connection is kept alive.
With this patch, idling client handling threads will shutdown after 5 seconds.
Note that threads that are kept busy by a client will not shutdown.
