### PR TITLE
Fix for issue with spaces in file names

### DIFF
--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -1095,10 +1095,10 @@ public abstract class NanoHTTPD {
                         if (contentDisposition == null) {
                             throw new ResponseException(Response.Status.BAD_REQUEST, "BAD REQUEST: Content type is multipart/form-data but no content-disposition info found. Usage: GET /example/file.html");
                         }
-                        StringTokenizer st = new StringTokenizer(contentDisposition, "; ");
+                        StringTokenizer st = new StringTokenizer(contentDisposition, ";");
                         Map<String, String> disposition = new HashMap<String, String>();
                         while (st.hasMoreTokens()) {
-                            String token = st.nextToken();
+                            String token = st.nextToken().trim();
                             int p = token.indexOf('=');
                             if (p != -1) {
                                 disposition.put(token.substring(0, p).trim().toLowerCase(Locale.US), token.substring(p + 1).trim());


### PR DESCRIPTION
This should fix the problem posted here: 
https://github.com/NanoHttpd/nanohttpd/issues/92

The problem was that operation 'new StringTokenizer("; ")' used semicolon and space as delimiters. So if a filename has spaces, then it will be split into multiple tokens and only the first token accepted.
