### PR TITLE
Return null value leads to NullPointerException

### DIFF
--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -1201,7 +1201,7 @@ public abstract class NanoHTTPD {
                     dest.write(src.slice());
                     path = tempFile.getName();
                 } catch (Exception e) { // Catch exception if any
-                    System.err.println("Error: " + e.getMessage());
+                    throw new Error(e); // we won't recover, so throw an error
                 } finally {
                     safeClose(fileOutputStream);
                 }
@@ -1214,9 +1214,8 @@ public abstract class NanoHTTPD {
                 TempFile tempFile = tempFileManager.createTempFile();
                 return new RandomAccessFile(tempFile.getName(), "rw");
             } catch (Exception e) {
-                System.err.println("Error: " + e.getMessage());
+            	throw new Error(e); // we won't recover, so throw an error
             }
-            return null;
         }
 
         /**


### PR DESCRIPTION
I tried to build NanoHttpd on my (Linux-) machine and the build fails, because of a `too many open files` error in `HttpKeepAliveTest`.

The cause of the problem is not easy to identify, because at the location where the error occurs it is ignored and a null value is returned which later leads to a NullPointerException, which hides the actual location in the source code where the error occurred.

This patch makes sure that if an error occurs it is reported accurately even if it cannot be handled.
