### PR TITLE
Allow custom http response codes

### DIFF
--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -549,7 +549,7 @@ public abstract class NanoHTTPD {
         /**
          * HTTP status code after processing, e.g. "200 OK", HTTP_OK
          */
-        private Status status;
+        private IStatus status;
         /**
          * MIME type of content, e.g. "text/html"
          */
@@ -581,7 +581,7 @@ public abstract class NanoHTTPD {
         /**
          * Basic constructor.
          */
-        public Response(Status status, String mimeType, InputStream data) {
+        public Response(IStatus status, String mimeType, InputStream data) {
             this.status = status;
             this.mimeType = mimeType;
             this.data = data;
@@ -590,7 +590,7 @@ public abstract class NanoHTTPD {
         /**
          * Convenience method that makes an InputStream out of given text.
          */
-        public Response(Status status, String mimeType, String txt) {
+        public Response(IStatus status, String mimeType, String txt) {
             this.status = status;
             this.mimeType = mimeType;
             try {
@@ -689,7 +689,7 @@ public abstract class NanoHTTPD {
             }
         }
 
-        public Status getStatus() {
+        public IStatus getStatus() {
             return status;
         }
 
@@ -724,11 +724,16 @@ public abstract class NanoHTTPD {
         public void setChunkedTransfer(boolean chunkedTransfer) {
             this.chunkedTransfer = chunkedTransfer;
         }
+        
+        public interface IStatus {
+            int getRequestStatus();
+            String getDescription();
+        }
 
         /**
          * Some HTTP response status codes
          */
-        public enum Status {
+        public enum Status implements IStatus {
             OK(200, "OK"), CREATED(201, "Created"), ACCEPTED(202, "Accepted"), NO_CONTENT(204, "No Content"), PARTIAL_CONTENT(206, "Partial Content"), REDIRECT(301,
                 "Moved Permanently"), NOT_MODIFIED(304, "Not Modified"), BAD_REQUEST(400, "Bad Request"), UNAUTHORIZED(401,
                 "Unauthorized"), FORBIDDEN(403, "Forbidden"), NOT_FOUND(404, "Not Found"), METHOD_NOT_ALLOWED(405, "Method Not Allowed"), RANGE_NOT_SATISFIABLE(416,
@@ -741,10 +746,12 @@ public abstract class NanoHTTPD {
                 this.description = description;
             }
 
+            @Override
             public int getRequestStatus() {
                 return this.requestStatus;
             }
 
+            @Override
             public String getDescription() {
                 return "" + this.requestStatus + " " + description;
             }


### PR DESCRIPTION
When I wanted to return a response with code 302, I noticed that this is not (easily) possible right now. Since it is _Nano_HTTPD it may make sense to not support everything out of the box, but I believe that people should be able to use custom response codes nevertheless.

I changed the code so that custom response code can easily be used by implementing the IStatus interface.
