### PR TITLE
Improve POST method management in case of no parameter entry in the post...

### DIFF
--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -991,7 +991,6 @@ public abstract class NanoHTTPD {
 
                         decodeMultipartData(boundary, fbuf, in, parms, files);
                     } else {
-                        // Handle application/x-www-form-urlencoded
                         String postLine = "";
                         StringBuilder postLineBuffer = new StringBuilder();
                         char pbuf[] = new char[512];
@@ -1002,7 +1001,13 @@ public abstract class NanoHTTPD {
                             read = in.read(pbuf);
                         }
                         postLine = postLineBuffer.toString().trim();
-                        decodeParms(postLine, parms);
+                        // Handle application/x-www-form-urlencoded
+                        if ("application/x-www-form-urlencoded".equalsIgnoreCase(contentType)) {
+                        	decodeParms(postLine, parms);
+                        } else if (postLine.length() != 0) {
+                        	// Special case for raw POST data => create a special files entry "postData" with raw content data
+                        	files.put("postData", postLine);
+                        }
                     }
                 } else if (Method.PUT.equals(method)) {
                     files.put("content", saveTmpFile(fbuf, 0, fbuf.limit()));
@@ -1261,7 +1266,7 @@ public abstract class NanoHTTPD {
             return parms;
         }
 
-        public String getQueryParameterString() {
+		public String getQueryParameterString() {
             return queryParameterString;
         }
 

--- a/core/src/test/java/fi/iki/elonen/HttpPostRequestTest.java
+++ b/core/src/test/java/fi/iki/elonen/HttpPostRequestTest.java
@@ -17,6 +17,22 @@ public class HttpPostRequestTest extends HttpServerTest {
     public static final String VALUE = "Summer vacation";
     public static final String FIELD2 = "location";
     public static final String VALUE2 = "Grand Canyon";
+    public static final String POST_RAW_CONTENT_FILE_ENTRY = "postData";
+    public static final String VALUE_TEST_SIMPLE_RAW_DATA_WITH_AMPHASIS = "Test raw data & Result value";
+
+    @Test
+    public void testSimpleRawPostData() throws Exception {
+        String header = "POST " + URI + " HTTP/1.1\n";
+        String content = VALUE_TEST_SIMPLE_RAW_DATA_WITH_AMPHASIS + "\n";
+        int size = content.length() + header.length();
+        int contentLengthHeaderValueSize = String.valueOf(size).length();
+        int contentLength = size + contentLengthHeaderValueSize + CONTENT_LENGTH.length();
+        String input = header + CONTENT_LENGTH + (contentLength+4) + "\r\n\r\n" + content;
+        invokeServer(input);
+        assertEquals(0, testServer.parms.size());
+        assertEquals(1, testServer.files.size());
+        assertEquals(VALUE_TEST_SIMPLE_RAW_DATA_WITH_AMPHASIS, testServer.files.get(POST_RAW_CONTENT_FILE_ENTRY));
+    }
 
     @Test
     public void testSimplePostWithSingleMultipartFormField() throws Exception {


### PR DESCRIPTION
Improve POST method management in case of no parameter entry in the post data (no 'form-data' or 'x-www-form-urlencoded' contentType) but raw data like this kind of request:

POST HTTP/1.1
Host: 192.168.5.66:1881?action=setParamMonitor
Cache-Control: no-cache

{ "dests":[ "M*" ], "eraseAll":0, "paramMonitor":{ "numbers":{ "eraseAll":0, "groups":[ { "name":"Test de groupe", "data":[ { "label":"Data 1 & 3", "num":"1" }, { "label":"Data 2", "num":"2" } ] } ] } } }
