### PR TITLE
Fix headers not cleared between multiple requests on same connection (HT...

### DIFF
--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -898,6 +898,8 @@ public abstract class NanoHTTPD {
                 parms = new HashMap<String, String>();
                 if(null == headers) {
                     headers = new HashMap<String, String>();
+                } else {
+                    headers.clear();
                 }
 
                 // Create a BufferedReader for parsing the header.


### PR DESCRIPTION
Hi, 

The HTTPSession object will handle multiple requests on the same connection by calling execute in a loop. But it looks like the http headers are not cleaned up between requests. 

For example; it a GET follows a POST (eg. favicon.ico) the headers will still contain an incorrect header-length, leading to a socket timeout as the server will be waiting for non existent data.

I think this simple fix will solve the problem. Unless there is a reason to keep the headers?

Cheers, Rien