### PR TITLE
make server socket reuse address

### DIFF
--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -152,6 +152,7 @@ public abstract class NanoHTTPD {
      */
     public void start() throws IOException {
         myServerSocket = new ServerSocket();
+        myServerSocket.setReuseAddress(true);
         myServerSocket.bind((hostname != null) ? new InetSocketAddress(hostname, myPort) : new InetSocketAddress(myPort));
 
         myThread = new Thread(new Runnable() {


### PR DESCRIPTION
To avoid exception java.net.BindException: bind failed: EADDRINUSE (Address already in use) at binding to address already in use.