### PR TITLE
Support <input type="file" multiple>

### DIFF
--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -1147,7 +1147,15 @@ public abstract class NanoHTTPD {
                             }
                             int offset = stripMultipartHeaders(fbuf, bpositions[boundarycount - 2]);
                             String path = saveTmpFile(fbuf, offset, bpositions[boundarycount - 1] - offset - 4);
-                            files.put(pname, path);
+                            if(!files.containsKey(pname)) {
+                            	files.put(pname, path);
+                            } else {
+                            	int count = 2;
+                            	while(files.containsKey(pname+count)) {
+                            		count++;
+                            	};
+                            	files.put(pname+count, path);
+                            }
                             value = disposition.get("filename");
                             value = value.substring(1, value.length() - 1);
                             do {


### PR DESCRIPTION
If several files are uploaded using a single input field (multiple), enumerate files and make them all available.

If 3 files are uploaded using:
<input name="upload" type="file" multiple>

They are named by ```session.parseBody(files);```:
upload
upload2
upload3

This way backward compatibilty is preserved.