### PR TITLE
Response.setStatus now accepts arbitrary IStatus-derived instances

### DIFF
--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -702,7 +702,7 @@ public abstract class NanoHTTPD {
             return status;
         }
 
-        public void setStatus(Status status) {
+        public void setStatus(IStatus status) {
             this.status = status;
         }
 


### PR DESCRIPTION
I noticed that I cannot use setStatus to set my own status codes.
This should fix it.