### PR TITLE
Fixed encoding when sending text payloads

### DIFF
--- a/websocket/src/main/java/fi/iki/elonen/WebSocketFrame.java
+++ b/websocket/src/main/java/fi/iki/elonen/WebSocketFrame.java
@@ -280,7 +280,6 @@ public class WebSocketFrame {
 
     public static final Charset TEXT_CHARSET = Charset.forName("UTF-8");
     public static final CharsetDecoder TEXT_DECODER = TEXT_CHARSET.newDecoder();
-    public static final CharsetEncoder TEXT_ENCODER = TEXT_CHARSET.newEncoder();
 
 
     public static String binary2Text(byte[] payload) throws CharacterCodingException {
@@ -292,7 +291,7 @@ public class WebSocketFrame {
     }
 
     public static byte[] text2Binary(String payload) throws CharacterCodingException {
-        return TEXT_ENCODER.encode(CharBuffer.wrap(payload)).array();
+        return payload.getBytes(TEXT_CHARSET);
     }
 
     @Override


### PR DESCRIPTION
The websocket server was adding a number of zero-bytes to the end of a message when using `Websocket.send(String)`. The additional bytes would be invisible when printed, but become problematic for example when parsing JSON data. 

To verify, run a simple echo server that sends back the text payload:

```
@Override
protected void onMessage(WebSocketFrame messageFrame) {
    try {
        this.send(messageFrame.getTextPayload());
    } catch (IOException e) {
        e.printStackTrace();
    }
```

And use the following client code with adjusted `IP` and `PORT`:

```
<html>
<body>
<script>
function log(msg) { document.getElementsByTagName("body")[0].innerHTML += msg+"<br/>"; }

var websocket = new WebSocket("ws://IP:PORT");

websocket.onopen = function() {
  var obj = { k: "v" };
  var msg = JSON.stringify(obj);

  log("Sending "+msg.length+" bytes: "+msg);
  log("Encoded: "+encodeURIComponent(msg));
  websocket.send(msg);
};

websocket.onmessage = function(e) {
  log("Received "+e.data.length+" bytes: "+e.data);
  log("Encoded: "+encodeURIComponent(e.data));
  var obj = JSON.parse(e.data);
};
</script>
</html>
```

This will cause the following output:

```
Sending 9 bytes: {"k":"v"}
Encoded: %7B%22k%22%3A%22v%22%7D
Received 18 bytes: {"k":"v"}
Encoded: %7B%22k%22%3A%22v%22%7D%00%00%00%00%00%00%00%00%00
```

Further, this will cause a parsing error on the `JSON.parse()` line, so the JSON that we received back is not parseable anymore.