### PR TITLE
Fix no warning in log if temp file was not deleted

### DIFF
--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -386,7 +386,9 @@ public abstract class NanoHTTPD {
         @Override
         public void delete() throws Exception {
             safeClose(this.fstream);
-            this.file.delete();
+            if (!this.file.delete()) {
+                throw new Exception("could not delete temporary file");
+            }
         }
 
         @Override


### PR DESCRIPTION
The method delete() of interface TempFile should message a failed delete by throwing an Exception. For the default implementation DefaultTempFile no Exceptions were thrown because the used method delete() of File does not throw an Exception on failure but returns false instead. This problem was fixed by now checking the return value and throwing an Exception if it is false.