### PR TITLE
Fix webserver serving folder named like index file

### DIFF
--- a/webserver/src/main/java/fi/iki/elonen/SimpleWebServer.java
+++ b/webserver/src/main/java/fi/iki/elonen/SimpleWebServer.java
@@ -279,7 +279,8 @@ public class SimpleWebServer extends NanoHTTPD {
     private String findIndexFileInDirectory(File directory) {
         for (String fileName : SimpleWebServer.INDEX_FILE_NAMES) {
             File indexFile = new File(directory, fileName);
-            if (indexFile.exists()) {
+            // check if file exists and is not a directory
+            if (indexFile.isFile()) {
                 return fileName;
             }
         }


### PR DESCRIPTION
If there was a directory named like an index file (e.g. "index.html"), other index files registered later (e.g. "index.htm") were ignored and the directory was served instead (or an index file in the directory). This was fixed by now checking if the index file is not a directory.