### PR TITLE
Fix working on Android < 4.4 and Java < 7

### DIFF
--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -1500,6 +1500,28 @@ public abstract class NanoHTTPD {
         }
     }
 
+    // ServerSocket does not implement Closeable on Android < 4.4 and Java < 7
+    private static final void safeClose(ServerSocket closeable) {
+        if (closeable != null) {
+            try {
+                closeable.close();
+            } catch (IOException e) {
+                NanoHTTPD.LOG.log(Level.SEVERE, "Could not close Socket", e);
+            }
+        }
+    }
+
+    // Socket does not implement Closeable on Android < 4.4 and Java < 7
+    private static final void safeClose(Socket closeable) {
+        if (closeable != null) {
+            try {
+                closeable.close();
+            } catch (IOException e) {
+                NanoHTTPD.LOG.log(Level.SEVERE, "Could not close Socket", e);
+            }
+        }
+    }
+
     private final String hostname;
 
     private final int myPort;


### PR DESCRIPTION
Two recently removed versions of overloaded static method safeClose() are still needed to compile or execute on older releases of Android and Java. This problem was fixed by adding the two static methods again.