### PR TITLE
Fix working on Android < 4.4 and Java < 7

### DIFF
--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -1293,7 +1293,7 @@ public abstract class NanoHTTPD {
 
         private void sendBodyWithCorrectEncoding(OutputStream outputStream, long pending) throws IOException {
             if (encodeAsGzip) {
-                GZIPOutputStream gzipOutputStream = new GZIPOutputStream(outputStream, true);
+                GZIPOutputStream gzipOutputStream = new GZIPOutputStream(outputStream);
                 sendBody(gzipOutputStream, -1);
                 gzipOutputStream.finish();
             } else {


### PR DESCRIPTION
A not yet available constructor of GZIPOutputStream was used.