### PR TITLE
set transfer encoding to chunked when response is gzip.

### DIFF
--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -1289,6 +1289,7 @@ public abstract class NanoHTTPD {
 
                 if (encodeAsGzip) {
                     pw.print("Content-Encoding: gzip\r\n");
+                    setChunkedTransfer(true);
                 }
 
                 long pending = this.data != null ? this.contentLength : 0;


### PR DESCRIPTION
sendContentLengthHeaderIfNotAlreadyPresent() will not be called when encodeAsGzip is true.
In this case, browser will not know where is the end of the response, until connection closed.

For example, in HelloServer, chrome will cost 5 seconds (which is the timeout and connection closed in nanoHttpd) to receive response, while it can be done in 37 ms by chunked transfer.

![before_after](https://cloud.githubusercontent.com/assets/2352900/8006989/7e3bf490-0bd3-11e5-9fdc-384e8ed0e710.png)