### PR TITLE
Added 408 Request Timeout to Status enum

### DIFF
--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -1087,6 +1087,7 @@ public abstract class NanoHTTPD {
             FORBIDDEN(403, "Forbidden"),
             NOT_FOUND(404, "Not Found"),
             METHOD_NOT_ALLOWED(405, "Method Not Allowed"),
+            REQUEST_TIMEOUT(408, "Request Timeout"),
             RANGE_NOT_SATISFIABLE(416, "Requested Range Not Satisfiable"),
             INTERNAL_ERROR(500, "Internal Server Error"),
             UNSUPPORTED_HTTP_VERSION(505, "HTTP Version Not Supported");


### PR DESCRIPTION
The 408 Request Timeout is the recommended response when performing HTTP Long Polling. https://tools.ietf.org/html/rfc6202#section-5.5

 https://tools.ietf.org/html/rfc7231#section-6.5.7 is useful when doing long polling with NanoHTTPD.