### PR TITLE
Added Mime type for HLS

### DIFF
--- a/webserver/src/main/java/fi/iki/elonen/SimpleWebServer.java
+++ b/webserver/src/main/java/fi/iki/elonen/SimpleWebServer.java
@@ -104,6 +104,8 @@ public class SimpleWebServer extends NanoHTTPD {
             put("zip", "application/octet-stream");
             put("exe", "application/octet-stream");
             put("class", "application/octet-stream");
+            put("m3u8", "application/vnd.apple.mpegurl");
+            put("ts", " video/mp2t");
         }
     };
 


### PR DESCRIPTION
HLS (http://fr.wikipedia.org/wiki/HTTP_Live_Streaming) can be implemented using SimpleWebServer by hosting m3u8 files and the corresponding mpeg-2 TS fragements. All that is missing are the mime types. The mime type for m3u8 is application/vnd.apple.mpegurl (https://tools.ietf.org/html/draft-pantos-http-live-streaming-04#section-3.1)  and the mime type for .ts is "video/mp2t" (ref: http://tools.ietf.org/html/rfc3555#page-38).

Question: Is it possible to force the m3u8 to be sent as utf-8?