### PR TITLE
keep line endings when using maven-java-formatter-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -385,6 +385,7 @@
 						</executions>
 						<configuration>
 							<configFile>${project.basedir}/../src/main/formatter/formatter.xml</configFile>
+							<lineEnding>KEEP</lineEnding>
 						</configuration>
 					</plugin>
 				</plugins>


### PR DESCRIPTION
Small change not to have modified files on windows.
previously the maven-java-formatter-plugin was changing some file line endings from LF to CRLF.

another possibility is to enforce one and only one line ending by using for example `<lineEnding>KEEP</lineEnding>` see [maven-java-formatter-plugin site](http://code.revelc.net/formatter-maven-plugin/format-mojo.html)