### PR TITLE
fixes #25 add basic CORS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,19 @@ NanoHTTPD project currently consist of four parts:
 * File server serves also very long files without memory overhead.
 * Contains a built-in list of most common MIME types.
 * Runtime extension support (extensions that serve particular MIME types) - example extension that serves Markdown formatted files. Simply including an extension JAR in the webserver classpath is enough for the extension to be loaded.
-* Simple [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) support via `--cors`
+* Simple [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) support via `--cors` paramater
   * by default serves `Access-Control-Allow-Headers: origin,accept,content-type`
   * possibility to set `Access-Control-Allow-Headers` by setting System property: `AccessControlAllowHeader`
   * _example: _ `-DAccessControlAllowHeader=origin,accept,content-type,Authorization`
+  * possible values:
+      * `--cors`: activates CORS support, `Access-Control-Allow-Origin` will be set to `*`
+      * `--cors=some_value`: `Access-Control-Allow-Origin` will be set to `some_value`. 
+
+**_CORS argument examples_**
+
+
+* `--cors=http://appOne.company.com`
+* `--cors="http://appOne.company.com, http://appTwo.company.com"`: note the double quotes so that the 2 URLs are considered part of a single argument.
 
 ## Maven dependencies
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ NanoHTTPD project currently consist of four parts:
 * File server serves also very long files without memory overhead.
 * Contains a built-in list of most common MIME types.
 * Runtime extension support (extensions that serve particular MIME types) - example extension that serves Markdown formatted files. Simply including an extension JAR in the webserver classpath is enough for the extension to be loaded.
+* Simple [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) support via `--cors`
+  * by default serves `Access-Control-Allow-Headers: origin,accept,content-type`
+  * possibility to set `Access-Control-Allow-Headers` by setting System property: `AccessControlAllowHeader`
+  * _example: _ `-DAccessControlAllowHeader=origin,accept,content-type,Authorization`
 
 ## Maven dependencies
 

--- a/webserver/src/main/java/fi/iki/elonen/SimpleWebServer.java
+++ b/webserver/src/main/java/fi/iki/elonen/SimpleWebServer.java
@@ -621,7 +621,7 @@ public class SimpleWebServer extends NanoHTTPD {
         return res;
     }
 
-    private Response addCORSHeaders(Map<String, String> queryHeaders, Response resp) {
+    protected Response addCORSHeaders(Map<String, String> queryHeaders, Response resp) {
         resp.addHeader("Access-Control-Allow-Origin", "*");
         resp.addHeader("Access-Control-Allow-Headers", calculateAllowHeaders(queryHeaders));
         resp.addHeader("Access-Control-Allow-Credentials", "true");

--- a/webserver/src/test/java/fi/iki/elonen/AbstractTestHttpServer.java
+++ b/webserver/src/test/java/fi/iki/elonen/AbstractTestHttpServer.java
@@ -1,0 +1,67 @@
+package fi.iki.elonen;
+
+/*
+ * #%L
+ * NanoHttpd-Webserver
+ * %%
+ * Copyright (C) 2012 - 2015 nanohttpd
+ * %%
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the nanohttpd nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import org.apache.http.HttpEntity;
+
+/**
+ * @author Matthieu Brouillard [matthieu@brouillard.fr]
+ */
+public class AbstractTestHttpServer {
+
+    protected byte[] readContents(HttpEntity entity) throws IOException {
+        InputStream instream = entity.getContent();
+        return readContents(instream);
+    }
+
+    protected byte[] readContents(InputStream instream) throws IOException {
+        byte[] bytes;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try {
+            byte[] buffer = new byte[1024];
+            int count;
+            while ((count = instream.read(buffer)) >= 0) {
+                out.write(buffer, 0, count);
+            }
+            bytes = out.toByteArray();
+        } finally {
+            instream.close();
+        }
+        return bytes;
+    }
+
+}

--- a/webserver/src/test/java/fi/iki/elonen/TestCorsHttpServer.java
+++ b/webserver/src/test/java/fi/iki/elonen/TestCorsHttpServer.java
@@ -43,6 +43,7 @@ import java.io.PipedOutputStream;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpOptions;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.junit.AfterClass;
@@ -50,7 +51,10 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TestHttpServer extends AbstractTestHttpServer {
+/**
+ * @author Matthieu Brouillard [matthieu@brouillard.fr]
+ */
+public class TestCorsHttpServer extends AbstractTestHttpServer {
 
     private static PipedOutputStream stdIn;
 
@@ -70,7 +74,8 @@ public class TestHttpServer extends AbstractTestHttpServer {
                     "--port",
                     "9090",
                     "--dir",
-                    "src/test/resources"
+                    "src/test/resources",
+                    "--cors"
                 };
                 SimpleWebServer.main(args);
             }
@@ -88,27 +93,13 @@ public class TestHttpServer extends AbstractTestHttpServer {
     }
 
     @Test
-    public void doTest404() throws Exception {
+    public void doTestOption() throws Exception {
         CloseableHttpClient httpclient = HttpClients.createDefault();
-        HttpGet httpget = new HttpGet("http://localhost:9090/xxx/yyy.html");
-        CloseableHttpResponse response = httpclient.execute(httpget);
-        Assert.assertEquals(404, response.getStatusLine().getStatusCode());
-        response.close();
-    }
-
-    @Test
-    public void doPlugin() throws Exception {
-        CloseableHttpClient httpclient = HttpClients.createDefault();
-        HttpGet httpget = new HttpGet("http://localhost:9090/index.xml");
-        CloseableHttpResponse response = httpclient.execute(httpget);
-        String string = new String(readContents(response.getEntity()), "UTF-8");
-        Assert.assertEquals("<xml/>", string);
-        response.close();
-
-        httpget = new HttpGet("http://localhost:9090/testdir/testdir/different.xml");
-        response = httpclient.execute(httpget);
-        string = new String(readContents(response.getEntity()), "UTF-8");
-        Assert.assertEquals("<xml/>", string);
+        HttpOptions httpOption = new HttpOptions("http://localhost:9090/xxx/yyy.html");
+        CloseableHttpResponse response = httpclient.execute(httpOption);
+        Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+        Assert.assertNotNull("Cors should have added a header: Access-Control-Allow-Origin", response.getLastHeader("Access-Control-Allow-Origin"));
+        Assert.assertEquals("Cors should have added a header: Access-Control-Allow-Origin: *", "*", response.getLastHeader("Access-Control-Allow-Origin").getValue());
         response.close();
     }
 
@@ -119,31 +110,45 @@ public class TestHttpServer extends AbstractTestHttpServer {
         CloseableHttpResponse response = httpclient.execute(httpget);
         HttpEntity entity = response.getEntity();
         String string = new String(readContents(entity), "UTF-8");
+
+        Assert.assertNotNull("Cors should have added a header: Access-Control-Allow-Origin", response.getLastHeader("Access-Control-Allow-Origin"));
+        Assert.assertEquals("Cors should have added a header: Access-Control-Allow-Origin: *", "*", response.getLastHeader("Access-Control-Allow-Origin").getValue());
         Assert.assertEquals("<html>\n<head>\n<title>dummy</title>\n</head>\n<body>\n\t<h1>it works</h1>\n</body>\n</html>", string);
         response.close();
+    }
 
-        httpget = new HttpGet("http://localhost:9090/");
-        response = httpclient.execute(httpget);
-        entity = response.getEntity();
-        string = new String(readContents(entity), "UTF-8");
-        Assert.assertTrue(string.indexOf("testdir") > 0);
+    @Test
+    public void testAccessControlAllowHeaderUsesDefaultsWithoutSystemProperty() throws Exception {
+        Assert.assertNull("no System " + SimpleWebServer.ACCESS_CONTROL_ALLOW_HEADER_PROPERTY_NAME + " shoudl be set",
+                System.getProperty(SimpleWebServer.ACCESS_CONTROL_ALLOW_HEADER_PROPERTY_NAME));
+
+        CloseableHttpClient httpclient = HttpClients.createDefault();
+        HttpOptions httpOption = new HttpOptions("http://localhost:9090/xxx/yyy.html");
+        CloseableHttpResponse response = httpclient.execute(httpOption);
+        Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+        Assert.assertEquals("Cors should have added a header: Access-Control-Allow-Headers: " + SimpleWebServer.DEFAULT_ALLOWED_HEADERS,
+                SimpleWebServer.DEFAULT_ALLOWED_HEADERS, response.getLastHeader("Access-Control-Allow-Headers").getValue());
         response.close();
+    }
 
-        httpget = new HttpGet("http://localhost:9090/testdir");
-        response = httpclient.execute(httpget);
-        entity = response.getEntity();
-        string = new String(readContents(entity), "UTF-8");
-        Assert.assertTrue(string.indexOf("test.html") > 0);
-        response.close();
+    @Test
+    public void testAccessControlAllowHeaderUsesSystemPropertyWhenSet() throws Exception {
+        Assert.assertNull("no System " + SimpleWebServer.ACCESS_CONTROL_ALLOW_HEADER_PROPERTY_NAME + " shoudl be set",
+                System.getProperty(SimpleWebServer.ACCESS_CONTROL_ALLOW_HEADER_PROPERTY_NAME));
 
-        httpget = new HttpGet("http://localhost:9090/testdir/testpdf.pdf");
-        response = httpclient.execute(httpget);
-        entity = response.getEntity();
+        final String expectedValue = "origin";
+        System.setProperty(SimpleWebServer.ACCESS_CONTROL_ALLOW_HEADER_PROPERTY_NAME, expectedValue);
 
-        byte[] actual = readContents(entity);
-        byte[] expected = readContents(new FileInputStream("src/test/resources/testdir/testpdf.pdf"));
-        Assert.assertArrayEquals(expected, actual);
-        response.close();
-
+        try {
+            CloseableHttpClient httpclient = HttpClients.createDefault();
+            HttpOptions httpOption = new HttpOptions("http://localhost:9090/xxx/yyy.html");
+            CloseableHttpResponse response = httpclient.execute(httpOption);
+            Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+            Assert.assertEquals("Cors should have added a header: Access-Control-Allow-Headers: " + expectedValue, expectedValue,
+                    response.getLastHeader("Access-Control-Allow-Headers").getValue());
+            response.close();
+        } finally {
+            System.clearProperty(SimpleWebServer.ACCESS_CONTROL_ALLOW_HEADER_PROPERTY_NAME);
+        }
     }
 }

--- a/webserver/src/test/java/fi/iki/elonen/TestCorsHttpServerWithSingleOrigin.java
+++ b/webserver/src/test/java/fi/iki/elonen/TestCorsHttpServerWithSingleOrigin.java
@@ -1,0 +1,121 @@
+package fi.iki.elonen;
+
+/*
+ * #%L
+ * NanoHttpd-Webserver
+ * %%
+ * Copyright (C) 2012 - 2015 nanohttpd
+ * %%
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the nanohttpd nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+import java.io.ByteArrayOutputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpOptions;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * @author Matthieu Brouillard [matthieu@brouillard.fr]
+ */
+public class TestCorsHttpServerWithSingleOrigin extends AbstractTestHttpServer {
+
+    private static PipedOutputStream stdIn;
+
+    private static Thread serverStartThread;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        stdIn = new PipedOutputStream();
+        System.setIn(new PipedInputStream(stdIn));
+        serverStartThread = new Thread(new Runnable() {
+
+            @Override
+            public void run() {
+                String[] args = {
+                    "--host",
+                    "localhost",
+                    "--port",
+                    "9090",
+                    "--dir",
+                    "src/test/resources",
+                    "--cors=http://localhost:9090"
+                };
+                SimpleWebServer.main(args);
+            }
+        });
+        serverStartThread.start();
+        // give the server some tine to start.
+        Thread.sleep(100);
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        stdIn.write("\n\n".getBytes());
+        serverStartThread.join(2000);
+        Assert.assertFalse(serverStartThread.isAlive());
+    }
+
+    @Test
+    public void doTestOption() throws Exception {
+        CloseableHttpClient httpclient = HttpClients.createDefault();
+        HttpOptions httpOption = new HttpOptions("http://localhost:9090/xxx/yyy.html");
+        CloseableHttpResponse response = httpclient.execute(httpOption);
+        Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+        Assert.assertNotNull("Cors should have added a header: Access-Control-Allow-Origin", response.getLastHeader("Access-Control-Allow-Origin"));
+        Assert.assertEquals("Cors should have added a header: Access-Control-Allow-Origin: http://localhost:9090", "http://localhost:9090",
+                response.getLastHeader("Access-Control-Allow-Origin").getValue());
+        response.close();
+    }
+
+    @Test
+    public void doSomeBasicTest() throws Exception {
+        CloseableHttpClient httpclient = HttpClients.createDefault();
+        HttpGet httpget = new HttpGet("http://localhost:9090/testdir/test.html");
+        CloseableHttpResponse response = httpclient.execute(httpget);
+        HttpEntity entity = response.getEntity();
+        String string = new String(readContents(entity), "UTF-8");
+
+        Assert.assertNotNull("Cors should have added a header: Access-Control-Allow-Origin", response.getLastHeader("Access-Control-Allow-Origin"));
+        Assert.assertEquals("Cors should have added a header: Access-Control-Allow-Origin: http://localhost:9090", "http://localhost:9090",
+                response.getLastHeader("Access-Control-Allow-Origin").getValue());
+        Assert.assertEquals("<html>\n<head>\n<title>dummy</title>\n</head>\n<body>\n\t<h1>it works</h1>\n</body>\n</html>", string);
+        response.close();
+    }
+}


### PR DESCRIPTION
Find embedded a small contribution to add a basic CORS support to NanoHttpd webserver.

I got inspired from:
* @kasakara answer in the [comment](https://github.com/NanoHttpd/nanohttpd/issues/25#issuecomment-52149315)
* @AdamBien in his [CORS project](https://github.com/AdamBien/cors)