### PR TITLE
Option to start main server thread as non-daemon

### DIFF
--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -1939,7 +1939,7 @@ public abstract class NanoHTTPD {
 
         ServerRunnable serverRunnable = createServerRunnable(timeout);
         this.myThread = new Thread(serverRunnable);
-        this.myThread.setDaemon(true);
+        this.myThread.setDaemon(mainServerDaemon);
         this.myThread.setName("NanoHttpd Main Listener");
         this.myThread.start();
         while (!serverRunnable.hasBinded && serverRunnable.bindException == null) {

--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -34,6 +34,7 @@ package fi.iki.elonen;
  */
 
 import java.io.*;
+import java.lang.IllegalStateException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
@@ -1635,6 +1636,8 @@ public abstract class NanoHTTPD {
      */
     private TempFileManagerFactory tempFileManagerFactory;
 
+    private boolean mainServerDaemon = true;
+
     /**
      * Constructs an HTTP server on given port.
      */
@@ -1891,6 +1894,19 @@ public abstract class NanoHTTPD {
      */
     public void setTempFileManagerFactory(TempFileManagerFactory tempFileManagerFactory) {
         this.tempFileManagerFactory = tempFileManagerFactory;
+    }
+
+    /**
+     * Set whether the main listener thread should be started as a daemon thread.
+     *
+     * @param daemon
+     *            whether to start the main thread as daemon
+     * @throws IllegalStateException
+     *             if the thread is already started
+     */
+    public void setMainServerDaemon(boolean daemon) throws IllegalStateException {
+        if(myThread != null && myThread.isAlive()) throw new IllegalStateException();
+        this.mainServerDaemon = daemon;
     }
 
     /**

--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -1636,7 +1636,7 @@ public abstract class NanoHTTPD {
      */
     private TempFileManagerFactory tempFileManagerFactory;
 
-    private boolean mainServerDaemon = true;
+    private boolean mainThreadDaemon = true;
 
     /**
      * Constructs an HTTP server on given port.
@@ -1904,9 +1904,9 @@ public abstract class NanoHTTPD {
      * @throws IllegalStateException
      *             if the thread is already started
      */
-    public void setMainServerDaemon(boolean daemon) throws IllegalStateException {
+    public void setMainThreadDaemon(boolean daemon) throws IllegalStateException {
         if(myThread != null && myThread.isAlive()) throw new IllegalStateException();
-        this.mainServerDaemon = daemon;
+        this.mainThreadDaemon = daemon;
     }
 
     /**
@@ -1939,7 +1939,7 @@ public abstract class NanoHTTPD {
 
         ServerRunnable serverRunnable = createServerRunnable(timeout);
         this.myThread = new Thread(serverRunnable);
-        this.myThread.setDaemon(mainServerDaemon);
+        this.myThread.setDaemon(mainThreadDaemon);
         this.myThread.setName("NanoHttpd Main Listener");
         this.myThread.start();
         while (!serverRunnable.hasBinded && serverRunnable.bindException == null) {


### PR DESCRIPTION
I'm working on a Java app based on an HTTP server that accepts requests and performs operations accordingly. As the `NanoHttpd Main Listener` thread is the only thread that keeps running, I need an option to make sure it is not started as a daemon thread.
This PR makes sure you can change this by running `setMainThreadDaemon(boolean flag)` while the main thread is stopped.