### PR TITLE
Added ServerSocketFactory to allow custom ServerSockets;

### DIFF
--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -2088,7 +2088,7 @@ public abstract class NanoHTTPD {
      *             if the socket is in use.
      */
     public void start(final int timeout, boolean daemon) throws IOException {
-        this.myServerSocket = this.serverSocketFactory.create();
+        this.myServerSocket = this.getServerSocketFactory().create();
         this.myServerSocket.setReuseAddress(true);
 
         ServerRunnable serverRunnable = createServerRunnable(timeout);

--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -478,7 +478,7 @@ public abstract class NanoHTTPD {
     /**
      * Creates a normal ServerSocket for TCP connections
      */
-    public class DefaultServerSocketFactory implements ServerSocketFactory {
+    public static class DefaultServerSocketFactory implements ServerSocketFactory {
 
         @Override
         public ServerSocket create() {
@@ -487,7 +487,7 @@ public abstract class NanoHTTPD {
             } catch (IOException e) {
                 e.printStackTrace();
             }
-            return myServerSocket;
+            return null;
         }
 
     }
@@ -495,7 +495,7 @@ public abstract class NanoHTTPD {
     /**
      * Creates a new SSLServerSocket
      */
-    public class SecureServerSocketFactory implements ServerSocketFactory {
+    public static class SecureServerSocketFactory implements ServerSocketFactory {
 
         private SSLServerSocketFactory sslServerSocketFactory;
 

--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -481,13 +481,8 @@ public abstract class NanoHTTPD {
     public static class DefaultServerSocketFactory implements ServerSocketFactory {
 
         @Override
-        public ServerSocket create() {
-            try {
-                return new ServerSocket();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-            return null;
+        public ServerSocket create() throws IOException {
+            return new ServerSocket();
         }
 
     }
@@ -507,21 +502,17 @@ public abstract class NanoHTTPD {
         }
 
         @Override
-        public ServerSocket create() {
+        public ServerSocket create() throws IOException {
             SSLServerSocket ss = null;
-            try {
-                ss = (SSLServerSocket) this.sslServerSocketFactory.createServerSocket();
-                if (this.sslProtocols != null) {
-                    ss.setEnabledProtocols(this.sslProtocols);
-                } else {
-                    ss.setEnabledProtocols(ss.getSupportedProtocols());
-                }
-                ss.setUseClientMode(false);
-                ss.setWantClientAuth(false);
-                ss.setNeedClientAuth(false);
-            } catch (IOException e) {
-                e.printStackTrace();
+            ss = (SSLServerSocket) this.sslServerSocketFactory.createServerSocket();
+            if (this.sslProtocols != null) {
+                ss.setEnabledProtocols(this.sslProtocols);
+            } else {
+                ss.setEnabledProtocols(ss.getSupportedProtocols());
             }
+            ss.setUseClientMode(false);
+            ss.setWantClientAuth(false);
+            ss.setNeedClientAuth(false);
             return ss;
         }
 
@@ -1621,7 +1612,7 @@ public abstract class NanoHTTPD {
      */
     public interface ServerSocketFactory {
 
-        public ServerSocket create();
+        public ServerSocket create() throws IOException;
 
     }
 

--- a/core/src/test/java/fi/iki/elonen/SSLServerSocketFactoryTest.java
+++ b/core/src/test/java/fi/iki/elonen/SSLServerSocketFactoryTest.java
@@ -1,0 +1,90 @@
+package fi.iki.elonen;
+
+import java.io.File;
+
+/*
+ * #%L
+ * NanoHttpd-Core
+ * %%
+ * Copyright (C) 2012 - 2015 nanohttpd
+ * %%
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the nanohttpd nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+import java.io.IOException;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.methods.HttpTrace;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import fi.iki.elonen.NanoHTTPD.SecureServerSocketFactory;
+
+public class SSLServerSocketFactoryTest extends HttpServerTest {
+
+    @Test
+    public void testSSLConnection() throws ClientProtocolException, IOException {
+        DefaultHttpClient httpclient = new DefaultHttpClient();
+        HttpTrace httphead = new HttpTrace("https://localhost:9043/index.html");
+        HttpResponse response = httpclient.execute(httphead);
+        HttpEntity entity = response.getEntity();
+        Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+
+        Assert.assertEquals(9043, this.testServer.getListeningPort());
+        Assert.assertTrue(this.testServer.isAlive());
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        System.setProperty("javax.net.ssl.trustStore", new File("src/test/resources/keystore.jks").getAbsolutePath());
+        this.testServer = new TestServer(9043);
+        this.testServer.setServerSocketFactory(new SecureServerSocketFactory(NanoHTTPD.makeSSLSocketFactory("/keystore.jks", "password".toCharArray()), null));
+        this.tempFileManager = new TestTempFileManager();
+        this.testServer.start();
+        try {
+            long start = System.currentTimeMillis();
+            Thread.sleep(100L);
+            while (!this.testServer.wasStarted()) {
+                Thread.sleep(100L);
+                if (System.currentTimeMillis() - start > 2000) {
+                    Assert.fail("could not start server");
+                }
+            }
+        } catch (InterruptedException e) {
+        }
+    }
+
+    @After
+    public void tearDown() {
+        this.testServer.stop();
+    }
+}

--- a/core/src/test/java/fi/iki/elonen/ServerSocketFactoryTest.java
+++ b/core/src/test/java/fi/iki/elonen/ServerSocketFactoryTest.java
@@ -1,0 +1,75 @@
+package fi.iki.elonen;
+
+/*
+ * #%L
+ * NanoHttpd-Core
+ * %%
+ * Copyright (C) 2012 - 2015 nanohttpd
+ * %%
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the nanohttpd nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ServerSocketFactoryTest extends NanoHTTPD {
+
+    public static final int PORT = 8192;
+
+    public ServerSocketFactoryTest() {
+        super(PORT);
+
+        this.setServerSocketFactory(new TestFactory());
+    }
+
+    @Test
+    public void isCustomServerSocketFactory() {
+        Assert.assertTrue(this.getServerSocketFactory() instanceof TestFactory);
+    }
+
+    @Test
+    public void testCreateServerSocket() {
+        ServerSocket ss = this.getServerSocketFactory().create();
+        Assert.assertTrue(ss != null);
+    }
+
+    private class TestFactory implements ServerSocketFactory {
+
+        @Override
+        public ServerSocket create() {
+            try {
+                return new ServerSocket();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            return null;
+        }
+    }
+}

--- a/core/src/test/java/fi/iki/elonen/ServerSocketFactoryTest.java
+++ b/core/src/test/java/fi/iki/elonen/ServerSocketFactoryTest.java
@@ -51,11 +51,13 @@ public class ServerSocketFactoryTest extends NanoHTTPD {
 
     @Test
     public void isCustomServerSocketFactory() {
+        System.out.println("CustomServerSocketFactory test");
         Assert.assertTrue(this.getServerSocketFactory() instanceof TestFactory);
     }
 
     @Test
     public void testCreateServerSocket() {
+        System.out.println("CreateServerSocket test");
         ServerSocket ss = this.getServerSocketFactory().create();
         Assert.assertTrue(ss != null);
     }

--- a/core/src/test/java/fi/iki/elonen/ServerSocketFactoryTest.java
+++ b/core/src/test/java/fi/iki/elonen/ServerSocketFactoryTest.java
@@ -1,5 +1,7 @@
 package fi.iki.elonen;
 
+import java.io.File;
+
 /*
  * #%L
  * NanoHttpd-Core
@@ -39,6 +41,9 @@ import java.net.ServerSocket;
 import org.junit.Assert;
 import org.junit.Test;
 
+import fi.iki.elonen.HttpServerTest.TestServer;
+import fi.iki.elonen.NanoHTTPD.SecureServerSocketFactory;
+
 public class ServerSocketFactoryTest extends NanoHTTPD {
 
     public static final int PORT = 8192;
@@ -58,8 +63,28 @@ public class ServerSocketFactoryTest extends NanoHTTPD {
     @Test
     public void testCreateServerSocket() {
         System.out.println("CreateServerSocket test");
-        ServerSocket ss = this.getServerSocketFactory().create();
+        ServerSocket ss = null;
+        try {
+            ss = this.getServerSocketFactory().create();
+        } catch (IOException e) {
+        }
         Assert.assertTrue(ss != null);
+    }
+
+    @Test
+    public void testSSLServerSocketFail() {
+        String[] protocols = {
+            ""
+        };
+        System.setProperty("javax.net.ssl.trustStore", new File("src/test/resources/keystore.jks").getAbsolutePath());
+        ServerSocketFactory ssFactory = new SecureServerSocketFactory(null, protocols);
+        ServerSocket ss = null;
+        try {
+            ss = ssFactory.create();
+        } catch (Exception e) {
+        }
+        Assert.assertTrue(ss == null);
+
     }
 
     private class TestFactory implements ServerSocketFactory {


### PR DESCRIPTION
I tried to provide my own ServerSocket classes, because I want to use my own Bouncycastle TLS implementation.
Since NanoHTTPD didn't have an option to create other ServerSockets than normal TCP or SSL-Sockets, I added the interface ServerSocketFactory and moved the ServerSocket creation into their own classes.

I also added recognition of (non-standard) \n\n-headers for more tolerance, as well as some public keywords in interfaces.