### PR TITLE
Fix content-length not being parsed as long

### DIFF
--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -920,7 +920,7 @@ public abstract class NanoHTTPD {
          */
         public long getBodySize() {
             if (this.headers.containsKey("content-length")) {
-                return Integer.parseInt(this.headers.get("content-length"));
+                return Long.parseLong(this.headers.get("content-length"));
             } else if (this.splitbyte < this.rlen) {
                 return this.rlen - this.splitbyte;
             }


### PR DESCRIPTION
The method getBodySize() returns a long. Parsing the content-length fields as ints limited the possible range (though the cases where this matters should still be rare).

Thanks!
