### PR TITLE
Allows WebSocket servers to easily override default HTTP behavior.

### DIFF
--- a/websocket/src/main/java/fi/iki/elonen/NanoWebSocketServer.java
+++ b/websocket/src/main/java/fi/iki/elonen/NanoWebSocketServer.java
@@ -842,8 +842,12 @@ public abstract class NanoWebSocketServer extends NanoHTTPD {
 
             return handshakeResponse;
         } else {
-            return super.serve(session);
+            return serveHttp(session);
         }
+    }
+    
+    protected Response serveHttp(final IHTTPSession session) {
+    	return super.serve(session);
     }
 
     /**


### PR DESCRIPTION
**Here's the deal:**
- You serve HTTP requests by overriding serve() on NanoHTTPD.
- NanoWebSocketServer (we should call it NanoWSD, as in WebSocket Daemon, btw ... if nothing else, it's consistent with NanoHTTPD) handles upgrade requests by overriding serve(), and if a request isn't a ws upgrade request it returns the default serve() from NanoHTTPD, which defaults to a 404 http response.


**Which leads to the following problem:**
If you want a webserver to handle both HTTP and WS, your only solution would be to override the serve() method in NanoWSD (yes I'm already calling it that, I really like it :p ), because you can no longer reach into NanoHTTPD.serve(), and then copy 90% of the code from NanoWSD.serve() into MyWebServer.serve(), which is really bad and just plain wrong in OOP.


**Of course you could just have NanoHTTPD running in one port and NanoWSD in another, but that has it's own issues:**
1) You may be unable to bind more than one port, which keeps you from running both servers.
1.1) If there are SRV records pointing a domain name to a specific port on a server you don't own, the above applies.
2) You have 2 servers running instead of 1, which means double the threads, double the memory used, double everything... and I really like to obsess over performance and memory footprints.
3) I like to complain over little things... and that's an issue because you'll be seeing me more often from now on :p 