### PR TITLE
WebSocket refactoring

### DIFF
--- a/websocket/src/main/java/fi/iki/elonen/NanoWebSocketServer.java
+++ b/websocket/src/main/java/fi/iki/elonen/NanoWebSocketServer.java
@@ -842,8 +842,12 @@ public abstract class NanoWebSocketServer extends NanoHTTPD {
 
             return handshakeResponse;
         } else {
-            return super.serve(session);
+            return serveHttp(session);
         }
+    }
+    
+    protected Response serveHttp(final IHTTPSession session) {
+    	return super.serve(session);
     }
 
     /**

--- a/websocket/src/main/java/fi/iki/elonen/samples/echo/DebugWebSocketServer.java
+++ b/websocket/src/main/java/fi/iki/elonen/samples/echo/DebugWebSocketServer.java
@@ -37,13 +37,13 @@ import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import fi.iki.elonen.NanoWebSocketServer;
-import fi.iki.elonen.NanoWebSocketServer.WebSocketFrame.CloseCode;
+import fi.iki.elonen.NanoWSD;
+import fi.iki.elonen.NanoWSD.WebSocketFrame.CloseCode;
 
 /**
  * @author Paul S. Hawke (paul.hawke@gmail.com) On: 4/23/14 at 10:31 PM
  */
-public class DebugWebSocketServer extends NanoWebSocketServer {
+public class DebugWebSocketServer extends NanoWSD {
 
     /**
      * logger to log to.

--- a/websocket/src/main/java/fi/iki/elonen/samples/echo/DebugWebSocketServer.java
+++ b/websocket/src/main/java/fi/iki/elonen/samples/echo/DebugWebSocketServer.java
@@ -38,6 +38,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import fi.iki.elonen.NanoWebSocketServer;
+import fi.iki.elonen.NanoWebSocketServer.WebSocketFrame.CloseCode;
 
 /**
  * @author Paul S. Hawke (paul.hawke@gmail.com) On: 4/23/14 at 10:31 PM
@@ -56,47 +57,64 @@ public class DebugWebSocketServer extends NanoWebSocketServer {
         this.debug = debug;
     }
 
-    @Override
-    protected void onClose(WebSocket socket, WebSocketFrame.CloseCode code, String reason, boolean initiatedByRemote) {
-        if (this.debug) {
-            System.out.println("C [" + (initiatedByRemote ? "Remote" : "Self") + "] " + (code != null ? code : "UnknownCloseCode[" + code + "]")
-                    + (reason != null && !reason.isEmpty() ? ": " + reason : ""));
-        }
-    }
+	@Override
+	protected WebSocket openWebSocket(IHTTPSession handshake) {
+		return new DebugWebSocket(this, handshake);
+	}
+	
+	private static class DebugWebSocket extends WebSocket{
+		private final DebugWebSocketServer server;
+		
+		public DebugWebSocket(DebugWebSocketServer server, IHTTPSession handshakeRequest) {
+			super(handshakeRequest);
+			this.server = server;
+		}
 
-    @Override
-    protected void onException(WebSocket socket, IOException e) {
-        DebugWebSocketServer.LOG.log(Level.SEVERE, "exception occured", e);
-    }
+		@Override
+		protected void onOpen(){}
 
-    @Override
-    protected void onFrameReceived(WebSocketFrame frame) {
-        if (this.debug) {
-            System.out.println("R " + frame);
-        }
-    }
+		@Override
+		protected void onClose(CloseCode code, String reason, boolean initiatedByRemote) {
+			if(server.debug) {
+	            System.out.println("C [" + (initiatedByRemote ? "Remote" : "Self") + "] " + (code != null ? code : "UnknownCloseCode[" + code + "]")
+	                    + (reason != null && !reason.isEmpty() ? ": " + reason : ""));
+	        }
+		}
 
-    @Override
-    protected void onMessage(WebSocket socket, WebSocketFrame messageFrame) {
-        try {
-            messageFrame.setUnmasked();
-            socket.sendFrame(messageFrame);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
+		@Override
+		protected void onMessage(WebSocketFrame message) {
+			try {
+	            message.setUnmasked();
+	            sendFrame(message);
+	        } catch (IOException e) {
+	            throw new RuntimeException(e);
+	        }
+		}
 
-    @Override
-    protected void onPong(WebSocket socket, WebSocketFrame pongFrame) {
-        if (this.debug) {
-            System.out.println("P " + pongFrame);
-        }
-    }
+		@Override
+		protected void onPong(WebSocketFrame pong) {
+			if (server.debug) {
+	            System.out.println("P " + pong);
+	        }
+		}
 
-    @Override
-    public void onSendFrame(WebSocketFrame frame) {
-        if (this.debug) {
-            System.out.println("S " + frame);
-        }
-    }
+		@Override
+		protected void onException(IOException exception) {
+			DebugWebSocketServer.LOG.log(Level.SEVERE, "exception occured", exception);
+		}
+		
+		@Override
+	    protected void debugFrameReceived(WebSocketFrame frame) {
+	        if (server.debug) {
+	            System.out.println("R " + frame);
+	        }
+	    }
+
+	    @Override
+	    protected void debugFrameSent(WebSocketFrame frame) {
+	        if (server.debug) {
+	            System.out.println("S " + frame);
+	        }
+	    }
+	}
 }

--- a/websocket/src/main/java/fi/iki/elonen/samples/echo/EchoSocketSample.java
+++ b/websocket/src/main/java/fi/iki/elonen/samples/echo/EchoSocketSample.java
@@ -35,13 +35,13 @@ package fi.iki.elonen.samples.echo;
 
 import java.io.IOException;
 
-import fi.iki.elonen.NanoWebSocketServer;
+import fi.iki.elonen.NanoWSD;
 
 public class EchoSocketSample {
 
     public static void main(String[] args) throws IOException {
         final boolean debugMode = args.length >= 2 && args[1].toLowerCase().equals("-d");
-        NanoWebSocketServer ws = new DebugWebSocketServer(args.length > 0 ? Integer.parseInt(args[0]) : 9090, debugMode);
+        NanoWSD ws = new DebugWebSocketServer(args.length > 0 ? Integer.parseInt(args[0]) : 9090, debugMode);
         ws.start();
         System.out.println("Server started, hit Enter to stop.\n");
         try {

--- a/websocket/src/test/java/fi/iki/elonen/WebSocketResponseHandlerTest.java
+++ b/websocket/src/test/java/fi/iki/elonen/WebSocketResponseHandlerTest.java
@@ -38,6 +38,7 @@ import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNull;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -50,6 +51,8 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import fi.iki.elonen.NanoHTTPD.IHTTPSession;
 import fi.iki.elonen.NanoHTTPD.Response;
+import fi.iki.elonen.NanoWebSocketServer.WebSocketFrame;
+import fi.iki.elonen.NanoWebSocketServer.WebSocketFrame.CloseCode;
 
 @RunWith(MockitoJUnitRunner.class)
 public class WebSocketResponseHandlerTest {
@@ -60,10 +63,31 @@ public class WebSocketResponseHandlerTest {
     private NanoWebSocketServer nanoWebSocketServer;
 
     private Map<String, String> headers;
-
+    
+    private static class MockedWSD extends NanoWebSocketServer{
+    	public MockedWSD(int port) {
+			super(port);
+		}
+    	
+		public MockedWSD(String hostname, int port) {
+			super(hostname, port);
+		}
+		
+		@Override
+		protected WebSocket openWebSocket(IHTTPSession handshake) {
+			return new WebSocket(handshake) { // Dummy websocket inner class.
+				@Override protected void onPong(WebSocketFrame pong) {}
+				@Override protected void onOpen() {}
+				@Override protected void onMessage(WebSocketFrame message) {}
+				@Override protected void onException(IOException exception) {}
+				@Override protected void onClose(CloseCode code, String reason, boolean initiatedByRemote) {}
+			};
+		}
+    }
+    
     @Before
     public void setUp() {
-        this.nanoWebSocketServer = Mockito.mock(NanoWebSocketServer.class, Mockito.CALLS_REAL_METHODS);
+        this.nanoWebSocketServer = Mockito.mock(MockedWSD.class, Mockito.CALLS_REAL_METHODS);
 
         this.headers = new HashMap<String, String>();
         this.headers.put("upgrade", "websocket");

--- a/websocket/src/test/java/fi/iki/elonen/WebSocketResponseHandlerTest.java
+++ b/websocket/src/test/java/fi/iki/elonen/WebSocketResponseHandlerTest.java
@@ -51,8 +51,8 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import fi.iki.elonen.NanoHTTPD.IHTTPSession;
 import fi.iki.elonen.NanoHTTPD.Response;
-import fi.iki.elonen.NanoWebSocketServer.WebSocketFrame;
-import fi.iki.elonen.NanoWebSocketServer.WebSocketFrame.CloseCode;
+import fi.iki.elonen.NanoWSD.WebSocketFrame;
+import fi.iki.elonen.NanoWSD.WebSocketFrame.CloseCode;
 
 @RunWith(MockitoJUnitRunner.class)
 public class WebSocketResponseHandlerTest {
@@ -60,11 +60,11 @@ public class WebSocketResponseHandlerTest {
     @Mock
     private IHTTPSession session;
 
-    private NanoWebSocketServer nanoWebSocketServer;
+    private NanoWSD nanoWebSocketServer;
 
     private Map<String, String> headers;
     
-    private static class MockedWSD extends NanoWebSocketServer{
+    private static class MockedWSD extends NanoWSD{
     	public MockedWSD(int port) {
 			super(port);
 		}
@@ -113,8 +113,8 @@ public class WebSocketResponseHandlerTest {
 
         assertNotNull(handshakeResponse);
 
-        assertEquals(handshakeResponse.getHeader(NanoWebSocketServer.HEADER_WEBSOCKET_ACCEPT), "HSmrc0sMlYUkAGmm5OPpG2HaGWk=");
-        assertEquals(handshakeResponse.getHeader(NanoWebSocketServer.HEADER_WEBSOCKET_PROTOCOL), "chat");
+        assertEquals(handshakeResponse.getHeader(NanoWSD.HEADER_WEBSOCKET_ACCEPT), "HSmrc0sMlYUkAGmm5OPpG2HaGWk=");
+        assertEquals(handshakeResponse.getHeader(NanoWSD.HEADER_WEBSOCKET_PROTOCOL), "chat");
     }
 
     @Test
@@ -131,14 +131,14 @@ public class WebSocketResponseHandlerTest {
     public void testWrongConnectionHeaderReturnsNullResponse() {
         this.headers.put("connection", "Junk");
         Response handshakeResponse = this.nanoWebSocketServer.serve(this.session);
-        assertNull(handshakeResponse.getHeader(NanoWebSocketServer.HEADER_UPGRADE));
+        assertNull(handshakeResponse.getHeader(NanoWSD.HEADER_UPGRADE));
     }
 
     @Test
     public void testWrongUpgradeHeaderReturnsNullResponse() {
         this.headers.put("upgrade", "not a websocket");
         Response handshakeResponse = this.nanoWebSocketServer.serve(this.session);
-        assertNull(handshakeResponse.getHeader(NanoWebSocketServer.HEADER_UPGRADE));
+        assertNull(handshakeResponse.getHeader(NanoWSD.HEADER_UPGRADE));
     }
 
     @Test

--- a/websocket/src/test/java/fi/iki/elonen/samples/echo/EchoWebSocketsTest.java
+++ b/websocket/src/test/java/fi/iki/elonen/samples/echo/EchoWebSocketsTest.java
@@ -43,11 +43,11 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import fi.iki.elonen.NanoWebSocketServer;
+import fi.iki.elonen.NanoWSD;
 
 public class EchoWebSocketsTest {
 
-    private static NanoWebSocketServer server;
+    private static NanoWSD server;
 
     @BeforeClass
     public static void setUp() throws Exception {


### PR DESCRIPTION
- `NanoWebSocketServer` renamed to `NanoWSD` as discussed.
- Removed event methods from `NanoWSD` and added them under `WebSocket` as abstract methods.
- Moved WebSocket Frame debug methods (on send / receive) from `NanoWSD` into `WebSocket` with name format `debugFrame<Received|Sent>()` as empty methods, so that IDEs don't force users to override them, thus keeping users from being tempted into adding code into them. Also added Javadocs explaining they are debug methods and should not be overriden unless for debug purposes.
- Added `WebSocket.onOpen()` event method that is called right after the `WebSocket` state changes to `State.OPEN`.
- Added `WebSocket.isOpen()` method that checks the internal state.
- Made the `WebSocket` class static and abstract, detaching it from `NanoWSD`.
- Made `NanoWSD.openSocket()` abstract. This is now the only method you have to override in this class. We could even make a `WebSocketFactory` interface and pass it as a constructor argument so that in most cases `NanoWSD` doesn't even need to be extended/overriden.
- Updated all the necessary tests accordingly.

As a side note, I've set up Travis-CI and Coveralls on a test branch of my fork (LordFokas/travis) so that everything I pull request into NanoHTTPD is tested against your own tests and standards before leaving my repo. Everything went fine, so I should assume it will be ok here. I've had issues with SSL and files while testing on my machine though, so the only way I can really test this is with online integration tools.

I'd also like to point out that I might put some work into increasing the coverage after this is accepted (assuming it is accepted), provided I get a stronger grip on tests... and I feel like I'm getting the hang of it quite well :)