### PR TITLE
Decode headers before write remote-addr

### DIFF
--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -808,17 +808,17 @@ public abstract class NanoHTTPD {
                     this.headers.clear();
                 }
 
-                if (null != this.remoteIp) {
-                    this.headers.put("remote-addr", this.remoteIp);
-                    this.headers.put("http-client-ip", this.remoteIp);
-                }
-
                 // Create a BufferedReader for parsing the header.
                 BufferedReader hin = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(buf, 0, this.rlen)));
 
                 // Decode the header into parms and header java properties
                 Map<String, String> pre = new HashMap<String, String>();
                 decodeHeader(hin, pre, this.parms, this.headers);
+
+                if (null != this.remoteIp) {
+                    this.headers.put("remote-addr", this.remoteIp);
+                    this.headers.put("http-client-ip", this.remoteIp);
+                }
 
                 this.method = Method.lookup(pre.get("method"));
                 if (this.method == null) {


### PR DESCRIPTION
The original version will save real IP in headers["remote-addr"] and then write HTTP headers to variable headers. This may cause some security issues. Clients can easily override their real ip by add header 'remote-addr' in http requests.