### PR TITLE
Fix a security issue:

### DIFF
--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -808,17 +808,17 @@ public abstract class NanoHTTPD {
                     this.headers.clear();
                 }
 
-                if (null != this.remoteIp) {
-                    this.headers.put("remote-addr", this.remoteIp);
-                    this.headers.put("http-client-ip", this.remoteIp);
-                }
-
                 // Create a BufferedReader for parsing the header.
                 BufferedReader hin = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(buf, 0, this.rlen)));
 
                 // Decode the header into parms and header java properties
                 Map<String, String> pre = new HashMap<String, String>();
                 decodeHeader(hin, pre, this.parms, this.headers);
+
+                if (null != this.remoteIp) {
+                    this.headers.put("remote-addr", this.remoteIp);
+                    this.headers.put("http-client-ip", this.remoteIp);
+                }
 
                 this.method = Method.lookup(pre.get("method"));
                 if (this.method == null) {


### PR DESCRIPTION
	"remote-addr" and "http-client-ip" may be overwrited by a carefully/special http header:

	GET /test.html HTTP/1.1
	Accept: text/html, application/xhtml+xml, */*
	Accept-Language: zh-CN
	User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko
	Accept-Encoding: gzip, deflate
	Proxy-Connection: Keep-Alive
	Host: www.test.com
	Pragma: no-cache
	remote-addr:XXX.XXX.XXX.XXX
	http-client-ip:XXX.XXX.XXX.XXX

	The Moplus SDK of Baidu(Baidu.com) uses the library led to the following questions:
	http://blog.trendmicro.com/trendlabs-security-intelligence/setting-the-record-straight-on-moplus-sdk-and-the-wormhole-vulnerability
	http://www.wooyun.org/bugs/wooyun-2015-0148406