### PR TITLE
Code Quality fix - Printf-style format strings should not lead to unexpected behavior at runtime

### DIFF
--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -1256,7 +1256,7 @@ public abstract class NanoHTTPD {
             public void write(byte[] b, int off, int len) throws IOException {
                 if (len == 0)
                     return;
-                out.write(String.format("%x\r\n", len).getBytes());
+                out.write(String.format("%x\r%n", len).getBytes());
                 out.write(b, off, len);
                 out.write("\r\n".getBytes());
             }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2275 - “Printf-style format strings should not lead to unexpected behaviour at runtime”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S2275?layout=true

Please let me know if you have any questions.

Javed.