### PR TITLE
Code Quality Fix - Constructors call non overridable method

### DIFF
--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -2057,9 +2057,9 @@ public abstract class NanoHTTPD {
      * Pluggable strategy for asynchronously executing requests.
      * 
      * @param asyncRunner
-     *            new strategy for handling threads.
+     *            new strategy for handling threads.                 
      */
-    public void setAsyncRunner(AsyncRunner asyncRunner) {
+    public final void setAsyncRunner(AsyncRunner asyncRunner) {
         this.asyncRunner = asyncRunner;
     }
 
@@ -2067,9 +2067,9 @@ public abstract class NanoHTTPD {
      * Pluggable strategy for creating and cleaning up temporary files.
      * 
      * @param tempFileManagerFactory
-     *            new strategy for handling temp files.
+     *            new strategy for handling temp files.                
      */
-    public void setTempFileManagerFactory(TempFileManagerFactory tempFileManagerFactory) {
+    public final void setTempFileManagerFactory(TempFileManagerFactory tempFileManagerFactory) {
         this.tempFileManagerFactory = tempFileManagerFactory;
     }
 

--- a/nanolets/src/test/java/fi/iki/elonen/router/AppNanolets.java
+++ b/nanolets/src/test/java/fi/iki/elonen/router/AppNanolets.java
@@ -143,10 +143,10 @@ public class AppNanolets extends RouterNanoHTTPD {
     /**
      * Add the routes Every route is an absolute path Parameters starts with ":"
      * Handler class should implement @UriResponder interface If the handler not
-     * implement UriResponder interface - toString() is used
-     */
+     * implement UriResponder interface - toString() is used 
+	 */
     @Override
-    public void addMappings() {
+    public final void addMappings() {
         super.addMappings();
         addRoute("/user", UserHandler.class);
         addRoute("/user/:id", UserHandler.class);

--- a/websocket/src/main/java/fi/iki/elonen/NanoWSD.java
+++ b/websocket/src/main/java/fi/iki/elonen/NanoWSD.java
@@ -515,8 +515,8 @@ public abstract class NanoWSD extends NanoHTTPD {
             setBinaryPayload(clone.getBinaryPayload());
             setMaskingKey(clone.getMaskingKey());
         }
-
-        public byte[] getBinaryPayload() {
+                   
+        public final byte[] getBinaryPayload() {
             return this.payload;
         }
 
@@ -638,28 +638,28 @@ public abstract class NanoWSD extends NanoHTTPD {
             }
         }
 
-        public void setBinaryPayload(byte[] payload) {
+        public final void setBinaryPayload(byte[] payload) {
             this.payload = payload;
             this._payloadLength = payload.length;
             this._payloadString = null;
         }
 
-        public void setFin(boolean fin) {
+        public final void setFin(boolean fin) {
             this.fin = fin;
         }
 
-        public void setMaskingKey(byte[] maskingKey) {
+        public final void setMaskingKey(byte[] maskingKey) {
             if (maskingKey != null && maskingKey.length != 4) {
                 throw new IllegalArgumentException("MaskingKey " + Arrays.toString(maskingKey) + " hasn't length 4");
             }
             this.maskingKey = maskingKey;
         }
 
-        public void setOpCode(OpCode opcode) {
+        public final void setOpCode(OpCode opcode) {
             this.opCode = opcode;
         }
 
-        public void setTextPayload(String payload) throws CharacterCodingException {
+        public final void setTextPayload(String payload) throws CharacterCodingException {
             this.payload = text2Binary(payload);
             this._payloadLength = payload.length();
             this._payloadString = payload;


### PR DESCRIPTION
DevFactory is committed to improving code quality and advancing open source. Our team contributes their time to researching and identifying areas for code quality improvement in open source projects. We identified a fix for NanoHTTPD.
This pull request is focused on resolving occurrences of Sonar rule squid:S1699 - “Constructors should only call non-overridable methods”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1699
Please let me know if you have any questions. There is more to come.

Christian Ivan
DevFactory - Code Cleanup Team