### PR TITLE
Throw exception if keystore is not found in resources classpath when using SSL

### DIFF
--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -1728,6 +1728,11 @@ public abstract class NanoHTTPD {
         try {
             KeyStore keystore = KeyStore.getInstance(KeyStore.getDefaultType());
             InputStream keystoreStream = NanoHTTPD.class.getResourceAsStream(keyAndTrustStoreClasspathPath);
+
+            if (keystoreStream == null) {
+                throw new IOException("Unable to load keystore from classpath: " + keyAndTrustStoreClasspathPath);
+            }
+
             keystore.load(keystoreStream, passphrase);
             KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
             keyManagerFactory.init(keystore, passphrase);

--- a/core/src/test/java/fi/iki/elonen/LoadKeyStoreTest.java
+++ b/core/src/test/java/fi/iki/elonen/LoadKeyStoreTest.java
@@ -1,0 +1,82 @@
+package fi.iki.elonen;
+
+/*
+ * #%L
+ * NanoHttpd-Core
+ * %%
+ * Copyright (C) 2012 - 2015 nanohttpd
+ * %%
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the nanohttpd nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import javax.net.ssl.SSLServerSocketFactory;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class LoadKeyStoreTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void loadKeyStoreFromResources() throws Exception {
+        String keyStorePath = "/keystore.jks";
+        InputStream resourceAsStream = this.getClass().getResourceAsStream(keyStorePath);
+        assertNotNull(resourceAsStream);
+
+        SSLServerSocketFactory sslServerSocketFactory = NanoHTTPD.makeSSLSocketFactory(keyStorePath, "password".toCharArray());
+        assertNotNull(sslServerSocketFactory);
+    }
+
+    @Test
+    public void loadKeyStoreFromResourcesWrongPassword() throws Exception {
+        String keyStorePath = "/keystore.jks";
+        InputStream resourceAsStream = this.getClass().getResourceAsStream(keyStorePath);
+        assertNotNull(resourceAsStream);
+
+        thrown.expect(IOException.class);
+        NanoHTTPD.makeSSLSocketFactory(keyStorePath, "wrongpassword".toCharArray());
+    }
+
+    @Test
+    public void loadNonExistentKeyStoreFromResources() throws Exception {
+        String nonExistentPath = "/nokeystorehere.jks";
+        InputStream resourceAsStream = this.getClass().getResourceAsStream(nonExistentPath);
+        assertNull(resourceAsStream);
+
+        thrown.expect(IOException.class);
+        NanoHTTPD.makeSSLSocketFactory(nonExistentPath, "".toCharArray());
+    }
+
+}


### PR DESCRIPTION
When the keystore is loaded from the classpath, if it does not exist the corresponding `InputStream` is null causing the keystore `load` method to initialize an empty one which is not usable for SSL connections.

Suggested fix is to check for this null pointer and then throw a checked exception.