### PR TITLE
Avoid crashes when LICENSE.txt is not included.

### DIFF
--- a/webserver/src/main/java/fi/iki/elonen/SimpleWebServer.java
+++ b/webserver/src/main/java/fi/iki/elonen/SimpleWebServer.java
@@ -84,7 +84,7 @@ public class SimpleWebServer extends NanoHTTPD {
                 bytes.write(buffer, 0, count);
             }
             text = bytes.toString("UTF-8");
-        } catch (IOException e) {
+        } catch (Exception e) {
             text = "unknown";
         }
         LICENCE = text;


### PR DESCRIPTION
This small change avoids `NullPointerException` on Android devices when you try to access `SimpleWebServer` class.