### PR TITLE
Use `Method.valueOf()` instead of looping through `toString()`

### DIFF
--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -1195,12 +1195,15 @@ public abstract class NanoHTTPD {
         PATCH;
 
         static Method lookup(String method) {
-            for (Method m : Method.values()) {
-                if (m.toString().equalsIgnoreCase(method)) {
-                    return m;
-                }
+            if (method == null)
+                return null;
+
+            try {
+                return valueOf(method);
+            } catch (IllegalArgumentException e) {
+                // TODO: Log it?
+                return null;
             }
-            return null;
         }
     }
 
@@ -1320,8 +1323,9 @@ public abstract class NanoHTTPD {
 
         /**
          * Headers for the HTTP response. Use addHeader() to add lines. the
-         * lowercase map is automaticaly kept up to date.
+         * lowercase map is automatically kept up to date.
          */
+        @SuppressWarnings("serial")
         private final Map<String, String> header = new HashMap<String, String>() {
 
             public String put(String key, String value) {
@@ -1479,7 +1483,7 @@ public abstract class NanoHTTPD {
             }
         }
 
-        protected void printHeader(PrintWriter pw, String key, String value) {
+        protected static void printHeader(PrintWriter pw, String key, String value) {
             pw.append(key).append(": ").append(value).append("\r\n");
         }
 
@@ -1722,6 +1726,7 @@ public abstract class NanoHTTPD {
         return MIME_TYPES;
     }
 
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     private static void loadMimeTypes(Map<String, String> result, String resourceName) {
         try {
             Enumeration<URL> resources = NanoHTTPD.class.getClassLoader().getResources(resourceName);
@@ -1981,7 +1986,7 @@ public abstract class NanoHTTPD {
      *         accespts it. Default this option is on for text content and off
      *         for everything. Override this for custom semantics.
      */
-    protected boolean useGzipWhenAccepted(Response r) {
+    protected static boolean useGzipWhenAccepted(Response r) {
         return r.getMimeType() != null && r.getMimeType().toLowerCase().contains("text/");
     }
 

--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -1987,7 +1987,8 @@ public abstract class NanoHTTPD {
      *         accespts it. Default this option is on for text content and off
      *         for everything. Override this for custom semantics.
      */
-    protected static boolean useGzipWhenAccepted(Response r) {
+    @SuppressWarnings("static-method")
+	protected boolean useGzipWhenAccepted(Response r) {
         return r.getMimeType() != null && r.getMimeType().toLowerCase().contains("text/");
     }
 

--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -1483,7 +1483,8 @@ public abstract class NanoHTTPD {
             }
         }
 
-        protected static void printHeader(PrintWriter pw, String key, String value) {
+        @SuppressWarnings("static-method")
+        protected void printHeader(PrintWriter pw, String key, String value) {
             pw.append(key).append(": ").append(value).append("\r\n");
         }
 


### PR DESCRIPTION
Using `toString()` in Enum is unsafe as is can be overridden, `name()` is preferred. Moreover, `valueOf()` has the same effect as the lookup in `values()`.

Added a few warning suppression for Eclipse.
Fixed super-minor typo.