### PR TITLE
add HTTP verbs and status codes for WebDAV (RFC 4918)

### DIFF
--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -833,7 +833,7 @@ public abstract class NanoHTTPD {
 
                 this.method = Method.lookup(pre.get("method"));
                 if (this.method == null) {
-                    throw new ResponseException(Response.Status.BAD_REQUEST, "BAD REQUEST: Syntax error.");
+                    throw new ResponseException(Response.Status.BAD_REQUEST, "BAD REQUEST: Syntax error. HTTP verb "+pre.get("method")+" unhandled.");
                 }
 
                 this.uri = pre.get("uri");
@@ -1192,7 +1192,14 @@ public abstract class NanoHTTPD {
         OPTIONS,
         TRACE,
         CONNECT,
-        PATCH;
+        PATCH,
+        PROPFIND,
+        PROPPATCH,
+        MKCOL,
+        MOVE,
+        COPY,
+        LOCK,
+        UNLOCK;
 
         static Method lookup(String method) {
             for (Method m : Method.values()) {
@@ -1226,6 +1233,7 @@ public abstract class NanoHTTPD {
             ACCEPTED(202, "Accepted"),
             NO_CONTENT(204, "No Content"),
             PARTIAL_CONTENT(206, "Partial Content"),
+            MULTI_STATUS(207, "Multi-Status"),
             REDIRECT(301, "Moved Permanently"),
             NOT_MODIFIED(304, "Not Modified"),
             BAD_REQUEST(400, "Bad Request"),


### PR DESCRIPTION
Extra HTTP verbs:
PROPFIND, PROPPATCH, MKCOL, MOVE, COPY, LOCK, UNLOCK

Extra HTTP status code:
207  "Multi-Status"

More detailed BAD REQUEST error message:
When serving a request, if some data is left unconsumed then those data
corrupt the subsequent request. Extended error message makes it easier to identify.