### PR TITLE
Add ability to be able to set NotFound and NotImplemented handlers

### DIFF
--- a/nanolets/src/main/java/fi/iki/elonen/router/RouterNanoHTTPD.java
+++ b/nanolets/src/main/java/fi/iki/elonen/router/RouterNanoHTTPD.java
@@ -553,6 +553,14 @@ public class RouterNanoHTTPD extends NanoHTTPD {
         router.addRoute(url, 100, handler, initParameter);
     }
 
+    public <T extends UriResponder> void setNotImplementedHandler(Class<T> handler) {
+        router.setNotImplemented(handler);
+    }
+
+    public <T extends UriResponder> void setNotFoundHandler(Class<T> handler) {
+        router.setNotFoundHandler(handler);
+    }
+
     public void removeRoute(String url) {
         router.removeRoute(url);
     }


### PR DESCRIPTION
Add ability to be able to set NotFound and NotImplemented handlers since there is currently no ability to overwrite the ones that are set by addMapping().