### PR TITLE
Enable extension of ClientHandler and ServerRunnable

### DIFF
--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -171,7 +171,7 @@ public abstract class NanoHTTPD {
 
         private final Socket acceptSocket;
 
-        private ClientHandler(InputStream inputStream, Socket acceptSocket) {
+        public ClientHandler(InputStream inputStream, Socket acceptSocket) {
             this.inputStream = inputStream;
             this.acceptSocket = acceptSocket;
         }
@@ -1706,7 +1706,7 @@ public abstract class NanoHTTPD {
 
         private boolean hasBinded = false;
 
-        private ServerRunnable(int timeout) {
+        public ServerRunnable(int timeout) {
             this.timeout = timeout;
         }
 


### PR DESCRIPTION
Comments of createClientHandler and createServerRunnable talk about extending ClientHandler and ServerRunnable, but this also needs accessible constructors.