### PR TITLE
Closes #329, #286

### DIFF
--- a/core/src/test/java/fi/iki/elonen/HttpGetRequestTest.java
+++ b/core/src/test/java/fi/iki/elonen/HttpGetRequestTest.java
@@ -114,6 +114,7 @@ public class HttpGetRequestTest extends HttpServerTest {
     public void testEmptyHeadersSuppliedToServeMethodFromSimpleWorkingGetRequest() {
         invokeServer("GET " + HttpServerTest.URI + " HTTP/1.1");
         assertNotNull(this.testServer.parms);
+        assertNotNull(this.testServer.parameters);
         assertNotNull(this.testServer.header);
         assertNotNull(this.testServer.files);
         assertNotNull(this.testServer.uri);
@@ -140,6 +141,8 @@ public class HttpGetRequestTest extends HttpServerTest {
         invokeServer("GET " + HttpServerTest.URI + "?foo=bar&baz=zot HTTP/1.1");
         assertEquals("bar", this.testServer.parms.get("foo"));
         assertEquals("zot", this.testServer.parms.get("baz"));
+        assertEquals("bar", this.testServer.parameters.get("foo").get(0));
+        assertEquals("zot", this.testServer.parameters.get("baz").get(0));
     }
 
     @Test
@@ -147,6 +150,8 @@ public class HttpGetRequestTest extends HttpServerTest {
         invokeServer("GET " + HttpServerTest.URI + "?foo=&baz=zot HTTP/1.1");
         assertEquals("", this.testServer.parms.get("foo"));
         assertEquals("zot", this.testServer.parms.get("baz"));
+        assertEquals("", this.testServer.parameters.get("foo").get(0));
+        assertEquals("zot", this.testServer.parameters.get("baz").get(0));
     }
 
     @Test
@@ -154,6 +159,8 @@ public class HttpGetRequestTest extends HttpServerTest {
         invokeServer("GET " + HttpServerTest.URI + "?foo=&baz=zot HTTP/1.1\nAccept: text/html");
         assertEquals("", this.testServer.parms.get("foo"));
         assertEquals("zot", this.testServer.parms.get("baz"));
+        assertEquals("", this.testServer.parameters.get("foo").get(0));
+        assertEquals("zot", this.testServer.parameters.get("baz").get(0));
         assertEquals("text/html", this.testServer.header.get("accept"));
     }
 
@@ -189,12 +196,23 @@ public class HttpGetRequestTest extends HttpServerTest {
     public void testSingleGetParameter() {
         invokeServer("GET " + HttpServerTest.URI + "?foo=bar HTTP/1.1");
         assertEquals("bar", this.testServer.parms.get("foo"));
+        assertEquals("bar", this.testServer.parameters.get("foo").get(0));
+    }
+
+    @Test
+    public void testMultipleValueGetParameter() {
+        invokeServer("GET " + HttpServerTest.URI + "?foo=bar&foo=baz HTTP/1.1");
+        assertEquals("bar", this.testServer.parms.get("foo"));
+        assertEquals(2, this.testServer.parameters.get("foo").size());
+        assertEquals("bar", this.testServer.parameters.get("foo").get(0));
+        assertEquals("baz", this.testServer.parameters.get("foo").get(1));
     }
 
     @Test
     public void testSingleGetParameterWithNoValue() {
         invokeServer("GET " + HttpServerTest.URI + "?foo HTTP/1.1");
         assertEquals("", this.testServer.parms.get("foo"));
+        assertEquals("", this.testServer.parameters.get("foo").get(0));
     }
 
     @Test

--- a/core/src/test/java/fi/iki/elonen/HttpHeadRequestTest.java
+++ b/core/src/test/java/fi/iki/elonen/HttpHeadRequestTest.java
@@ -120,6 +120,7 @@ public class HttpHeadRequestTest extends HttpServerTest {
     public void testEmptyHeadersSuppliedToServeMethodFromSimpleWorkingGetRequest() {
         invokeServer("HEAD " + HttpServerTest.URI + " HTTP/1.1");
         assertNotNull(this.testServer.parms);
+        assertNotNull(this.testServer.parameters);
         assertNotNull(this.testServer.header);
         assertNotNull(this.testServer.files);
         assertNotNull(this.testServer.uri);
@@ -146,6 +147,8 @@ public class HttpHeadRequestTest extends HttpServerTest {
         invokeServer("HEAD " + HttpServerTest.URI + "?foo=bar&baz=zot HTTP/1.1");
         assertEquals("bar", this.testServer.parms.get("foo"));
         assertEquals("zot", this.testServer.parms.get("baz"));
+        assertEquals("bar", this.testServer.parameters.get("foo").get(0));
+        assertEquals("zot", this.testServer.parameters.get("baz").get(0));
     }
 
     @Test
@@ -153,6 +156,8 @@ public class HttpHeadRequestTest extends HttpServerTest {
         invokeServer("HEAD " + HttpServerTest.URI + "?foo=&baz=zot HTTP/1.1");
         assertEquals("", this.testServer.parms.get("foo"));
         assertEquals("zot", this.testServer.parms.get("baz"));
+        assertEquals("", this.testServer.parameters.get("foo").get(0));
+        assertEquals("zot", this.testServer.parameters.get("baz").get(0));
     }
 
     @Test
@@ -160,6 +165,8 @@ public class HttpHeadRequestTest extends HttpServerTest {
         invokeServer("HEAD " + HttpServerTest.URI + "?foo=&baz=zot HTTP/1.1\nAccept: text/html");
         assertEquals("", this.testServer.parms.get("foo"));
         assertEquals("zot", this.testServer.parms.get("baz"));
+        assertEquals("", this.testServer.parameters.get("foo").get(0));
+        assertEquals("zot", this.testServer.parameters.get("baz").get(0));
         assertEquals("text/html", this.testServer.header.get("accept"));
     }
 
@@ -176,12 +183,23 @@ public class HttpHeadRequestTest extends HttpServerTest {
     public void testSingleGetParameter() {
         invokeServer("HEAD " + HttpServerTest.URI + "?foo=bar HTTP/1.1");
         assertEquals("bar", this.testServer.parms.get("foo"));
+        assertEquals("bar", this.testServer.parameters.get("foo").get(0));
+    }
+
+    @Test
+    public void testMultipleValueGetParameter() {
+        invokeServer("HEAD " + HttpServerTest.URI + "?foo=bar&foo=baz HTTP/1.1");
+        assertEquals("bar", this.testServer.parms.get("foo"));
+        assertEquals(2, this.testServer.parameters.get("foo").size());
+        assertEquals("bar", this.testServer.parameters.get("foo").get(0));
+        assertEquals("baz", this.testServer.parameters.get("foo").get(1));
     }
 
     @Test
     public void testSingleGetParameterWithNoValue() {
         invokeServer("HEAD " + HttpServerTest.URI + "?foo HTTP/1.1");
         assertEquals("", this.testServer.parms.get("foo"));
+        assertEquals("", this.testServer.parameters.get("foo").get(0));
     }
 
     @Test

--- a/core/src/test/java/fi/iki/elonen/HttpPostRequestTest.java
+++ b/core/src/test/java/fi/iki/elonen/HttpPostRequestTest.java
@@ -94,6 +94,7 @@ public class HttpPostRequestTest extends HttpServerTest {
         invokeServer(input);
 
         assertEquals(1, this.testServer.parms.size());
+        assertEquals(1, this.testServer.parameters.size());
         BufferedReader reader = new BufferedReader(new FileReader(this.testServer.files.get(HttpPostRequestTest.FIELD)));
         List<String> lines = readLinesFromFile(reader);
         assertLinesOfText(new String[]{
@@ -110,7 +111,9 @@ public class HttpPostRequestTest extends HttpServerTest {
         invokeServer(input);
 
         String fileNameAfter = new ArrayList<String>(this.testServer.parms.values()).get(0);
+        assertEquals(fileNameWithSpace, fileNameAfter);
 
+        fileNameAfter = new ArrayList<String>(this.testServer.parameters.values().iterator().next()).get(0);
         assertEquals(fileNameWithSpace, fileNameAfter);
     }
 
@@ -131,6 +134,10 @@ public class HttpPostRequestTest extends HttpServerTest {
         assertEquals(2, this.testServer.parms.size());
         assertEquals(HttpPostRequestTest.VALUE, this.testServer.parms.get(HttpPostRequestTest.FIELD));
         assertEquals(HttpPostRequestTest.VALUE2, this.testServer.parms.get(HttpPostRequestTest.FIELD2));
+
+        assertEquals(2, this.testServer.parameters.size());
+        assertEquals(HttpPostRequestTest.VALUE, this.testServer.parameters.get(HttpPostRequestTest.FIELD).get(0));
+        assertEquals(HttpPostRequestTest.VALUE2, this.testServer.parameters.get(HttpPostRequestTest.FIELD2).get(0));
     }
 
     @Test
@@ -150,6 +157,10 @@ public class HttpPostRequestTest extends HttpServerTest {
         assertEquals(2, this.testServer.parms.size());
         assertEquals(HttpPostRequestTest.VALUE, this.testServer.parms.get(HttpPostRequestTest.FIELD));
         assertEquals(HttpPostRequestTest.VALUE2, this.testServer.parms.get(HttpPostRequestTest.FIELD2));
+
+        assertEquals(2, this.testServer.parameters.size());
+        assertEquals(HttpPostRequestTest.VALUE, this.testServer.parameters.get(HttpPostRequestTest.FIELD).get(0));
+        assertEquals(HttpPostRequestTest.VALUE2, this.testServer.parameters.get(HttpPostRequestTest.FIELD2).get(0));
     }
 
     @Test
@@ -167,6 +178,9 @@ public class HttpPostRequestTest extends HttpServerTest {
 
         assertEquals(1, this.testServer.parms.size());
         assertEquals(HttpPostRequestTest.VALUE, this.testServer.parms.get(HttpPostRequestTest.FIELD));
+
+        assertEquals(1, this.testServer.parameters.size());
+        assertEquals(HttpPostRequestTest.VALUE, this.testServer.parameters.get(HttpPostRequestTest.FIELD).get(0));
     }
 
     @Test
@@ -179,6 +193,7 @@ public class HttpPostRequestTest extends HttpServerTest {
         String input = header + HttpPostRequestTest.CONTENT_LENGTH + (contentLength + 4) + "\r\n\r\n" + content;
         invokeServer(input);
         assertEquals(0, this.testServer.parms.size());
+        assertEquals(0, this.testServer.parameters.size());
         assertEquals(1, this.testServer.files.size());
         assertEquals(HttpPostRequestTest.VALUE_TEST_SIMPLE_RAW_DATA_WITH_AMPHASIS, this.testServer.files.get(HttpPostRequestTest.POST_RAW_CONTENT_FILE_ENTRY));
     }
@@ -200,8 +215,10 @@ public class HttpPostRequestTest extends HttpServerTest {
         String input = header + HttpPostRequestTest.CONTENT_LENGTH + (contentLength + 4) + "\r\n\r\n" + content;
         invokeServer(input);
 
-        assertEquals("Parameter count did not match.", 2, this.testServer.parms.size());
-        assertEquals("Parameter value did not match", HttpPostRequestTest.VALUE2, this.testServer.parms.get(HttpPostRequestTest.FIELD2));
+        assertEquals("Parms count did not match.", 2, this.testServer.parms.size());
+        assertEquals("Parameters count did not match.", 2, this.testServer.parameters.size());
+        assertEquals("Param value did not match", HttpPostRequestTest.VALUE2, this.testServer.parms.get(HttpPostRequestTest.FIELD2));
+        assertEquals("Parameter value did not match", HttpPostRequestTest.VALUE2, this.testServer.parameters.get(HttpPostRequestTest.FIELD2).get(0));
         BufferedReader reader = new BufferedReader(new FileReader(this.testServer.files.get(HttpPostRequestTest.FIELD)));
         List<String> lines = readLinesFromFile(reader);
         assertLinesOfText(new String[]{
@@ -234,7 +251,8 @@ public class HttpPostRequestTest extends HttpServerTest {
         String input = header + HttpPostRequestTest.CONTENT_LENGTH + (contentLength + 4) + "\r\n\r\n" + content;
         invokeServer(input);
 
-        assertEquals("Parameter count did not match.", 2, this.testServer.parms.size());
+        assertEquals("Parm count did not match.", 2, this.testServer.parms.size());
+        assertEquals("Parameter count did not match.", 2, this.testServer.parameters.size());
         BufferedReader reader = new BufferedReader(new FileReader(this.testServer.files.get(HttpPostRequestTest.FIELD)));
         List<String> lines = readLinesFromFile(reader);
         assertLinesOfText(new String[]{
@@ -263,7 +281,8 @@ public class HttpPostRequestTest extends HttpServerTest {
 
         invokeServer(input);
 
-        assertEquals("Parameter count did not match.", 1, this.testServer.parms.size());
+        assertEquals("Parm count did not match.", 1, this.testServer.parms.size());
+        assertEquals("Parameter count did not match.", 1, this.testServer.parameters.size());
         BufferedReader reader = new BufferedReader(new FileReader(this.testServer.files.get(HttpPostRequestTest.FIELD)));
         List<String> lines = readLinesFromFile(reader);
         assertLinesOfText(fileContent.split(lineSeparator), lines);

--- a/core/src/test/java/fi/iki/elonen/HttpServerTest.java
+++ b/core/src/test/java/fi/iki/elonen/HttpServerTest.java
@@ -82,6 +82,8 @@ public class HttpServerTest {
 
         public Map<String, String> parms;
 
+        public Map<String, List<String>> parameters;
+
         public Map<String, String> files;
 
         public Map<String, List<String>> decodedParamters;
@@ -111,16 +113,18 @@ public class HttpServerTest {
             this.uri = session.getUri();
             this.method = session.getMethod();
             this.header = session.getHeaders();
-            this.parms = session.getParms();
             this.files = new HashMap<String, String>();
             try {
                 session.parseBody(this.files);
             } catch (Exception e) {
                 e.printStackTrace();
             }
+            this.parms = session.getParms();
+            this.parameters = session.getParameters();
             this.queryParameterString = session.getQueryParameterString();
             this.decodedParamtersFromParameter = decodeParameters(this.queryParameterString);
             this.decodedParamters = decodeParameters(session.getQueryParameterString());
+
             return this.response;
         }
     }

--- a/core/src/test/java/fi/iki/elonen/InvalidRequestTest.java
+++ b/core/src/test/java/fi/iki/elonen/InvalidRequestTest.java
@@ -44,6 +44,7 @@ public class InvalidRequestTest extends HttpServerTest {
         invokeServer("GET " + HttpServerTest.URI + "\r\nX-Important-Header: foo");
 
         assertNotNull(this.testServer.parms);
+        assertNotNull(this.testServer.parameters);
         assertTrue(this.testServer.header.size() > 0);
         assertNotNull(this.testServer.files);
         assertNotNull(this.testServer.uri);
@@ -54,6 +55,7 @@ public class InvalidRequestTest extends HttpServerTest {
         invokeServer("GET " + HttpServerTest.URI + " HTTP/1.1\r\nX-Important-Header: foo");
 
         assertNotNull(this.testServer.parms);
+        assertNotNull(this.testServer.parameters);
         assertTrue(this.testServer.header.size() > 0);
         assertNotNull(this.testServer.files);
         assertNotNull(this.testServer.uri);
@@ -63,6 +65,7 @@ public class InvalidRequestTest extends HttpServerTest {
     public void testPostRequestWithoutProtocol() {
         invokeServer("POST " + HttpServerTest.URI + "\r\nContent-Length: 123");
         assertNotNull(this.testServer.parms);
+        assertNotNull(this.testServer.parameters);
         assertTrue(this.testServer.header.size() > 0);
         assertNotNull(this.testServer.files);
         assertNotNull(this.testServer.uri);
@@ -72,6 +75,7 @@ public class InvalidRequestTest extends HttpServerTest {
     public void testPostRequestWithProtocol() {
         invokeServer("POST " + HttpServerTest.URI + " HTTP/1.1\r\nContent-Length: 123");
         assertNotNull(this.testServer.parms);
+        assertNotNull(this.testServer.parameters);
         assertTrue(this.testServer.header.size() > 0);
         assertNotNull(this.testServer.files);
         assertNotNull(this.testServer.uri);


### PR DESCRIPTION
IHTTPSesssion.parms is now a map to a list of values for a given key. The old getParms() interface still exists, but moving forward one should use getParameters()

This tramples on the previous PR by @roloreaper, but I feel this is a cleaner solution (plus it has tests :) ).