### PR TITLE
If ContentType header has 'json' in it, then the response will be GZIPed

### DIFF
--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -2137,7 +2137,7 @@ public abstract class NanoHTTPD {
      */
     @SuppressWarnings("static-method")
     protected boolean useGzipWhenAccepted(Response r) {
-        return r.getMimeType() != null && r.getMimeType().toLowerCase().contains("text/");
+        return r.getMimeType() != null && (r.getMimeType().toLowerCase().contains("text/") || r.getMimeType().toLowerCase().contains("/json"));
     }
 
     public final int getListeningPort() {


### PR DESCRIPTION
The server was like, if the "content-type" header of response has "text/" in it, then its response will be GZipped. I have added support to GZip the response if it has "/json" as well. When the content type is "application/json", it can be gzipped as it is a textual content anyway. By this, JSONP contents wont be gzipped as it will have content type header as "application/javascript"