### PR TITLE
Fix travis build setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-- oraclejdk7
+- openjdk7
 
 before_install:
   - cat ~/.m2/settings.xml


### PR DESCRIPTION
Oracle JDK 7 is no longer supported on Travis's default build environment, so switch to OpenJDK instead.