### PR TITLE
Travis build error fix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: java
 jdk:
 - openjdk7
 
+dist: trusty
+
 before_install:
   - cat ~/.m2/settings.xml
   - rm  ~/.m2/settings.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
 script:
     - mvn test; export MAVEN_RESULT=$?
     - if [ "$MAVEN_RESULT" -ne 0 ]; then exit 1; fi
-#    - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then mvn clean deploy --quiet --settings settings.xml; fi
+    - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then mvn clean deploy --quiet --settings settings.xml; fi
 
 after_success:
   - mvn clean test jacoco:report coveralls:report

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
 script:
     - mvn test; export MAVEN_RESULT=$?
     - if [ "$MAVEN_RESULT" -ne 0 ]; then exit 1; fi
-    - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then mvn clean deploy --quiet --settings settings.xml; fi
+#    - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then mvn clean deploy --quiet --settings settings.xml; fi
 
 after_success:
   - mvn clean test jacoco:report coveralls:report

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 It is being developed at Github and uses Apache Maven for builds & unit testing:
 
- * Build status: [![Build Status](https://api.travis-ci.org/RishiKeerthi/nanohttpd.png)](https://travis-ci.org/RishiKeerthi/nanohttpd)
+ * Build status: [![Build Status](https://api.travis-ci.org/NanoHttpd/nanohttpd.png)](https://travis-ci.org/NanoHttpd/nanohttpd)
  * Coverage Status: [![Coverage Status](https://coveralls.io/repos/NanoHttpd/nanohttpd/badge.svg)](https://coveralls.io/r/NanoHttpd/nanohttpd)
  * Current central released version: [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.nanohttpd/nanohttpd/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.nanohttpd/nanohttpd)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 It is being developed at Github and uses Apache Maven for builds & unit testing:
 
- * Build status: [![Build Status](https://api.travis-ci.org/NanoHttpd/nanohttpd.png)](https://travis-ci.org/NanoHttpd/nanohttpd)
+ * Build status: [![Build Status](https://api.travis-ci.org/RishiKeerthi/nanohttpd.png)](https://travis-ci.org/RishiKeerthi/nanohttpd)
  * Coverage Status: [![Coverage Status](https://coveralls.io/repos/NanoHttpd/nanohttpd/badge.svg)](https://coveralls.io/r/NanoHttpd/nanohttpd)
  * Current central released version: [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.nanohttpd/nanohttpd/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.nanohttpd/nanohttpd)
 


### PR DESCRIPTION
Travis build has been failed since travis migrated all build environment to xenial by default, which affected our build generation. Fixed it using dist: param set to trusty.

https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038/8