### PR TITLE
Create friendlier methods for accessing post response data

### DIFF
--- a/core/src/main/java/org/nanohttpd/protocols/http/HTTPSession.java
+++ b/core/src/main/java/org/nanohttpd/protocols/http/HTTPSession.java
@@ -666,6 +666,18 @@ public class HTTPSession implements IHTTPSession {
         }
     }
 
+    @Override
+    public Map<String, String> getPostBody() throws IOException, ResponseException {
+        Map<String, String> responseBody = new HashMap<>();
+        parseBody(responseBody);
+        return responseBody;
+    }
+
+    @Override
+    public String getPostData() throws IOException, ResponseException {
+        return getPostBody().get(POST_DATA);
+    }
+
     /**
      * Retrieves the content of a sent file and saves it to a temporary file.
      * The full path to the saved file is returned.

--- a/core/src/main/java/org/nanohttpd/protocols/http/IHTTPSession.java
+++ b/core/src/main/java/org/nanohttpd/protocols/http/IHTTPSession.java
@@ -85,6 +85,18 @@ public interface IHTTPSession {
     void parseBody(Map<String, String> files) throws IOException, ResponseException;
 
     /**
+     *
+     * @return the post response body
+     */
+    Map<String, String> getPostBody() throws IOException, ResponseException;
+
+    /**
+     *
+     * @return the post response data
+     */
+    String getPostData() throws IOException, ResponseException;
+
+    /**
      * Get the remote ip address of the requester.
      * 
      * @return the IP address.


### PR DESCRIPTION
I've added `org.nanohttpd.protocols.http.IHTTPSession#getPostBody` and `org.nanohttpd.protocols.http.IHTTPSession#getPostData` so users can easily identify how to retrieve the post response.