### PR TITLE
Server must not send content-length header field with 101 status code

### DIFF
--- a/core/src/main/java/org/nanohttpd/protocols/http/response/Response.java
+++ b/core/src/main/java/org/nanohttpd/protocols/http/response/Response.java
@@ -257,11 +257,16 @@ public class Response implements Closeable {
                 printHeader(pw, "Content-Encoding", "gzip");
                 setChunkedTransfer(true);
             }
+
+            // check if WebSocket handshaking is on
+            boolean wsHandshake = this.status == Status.SWITCH_PROTOCOL;
+
             long pending = this.data != null ? this.contentLength : 0;
             if (this.requestMethod != Method.HEAD && this.chunkedTransfer) {
                 printHeader(pw, "Transfer-Encoding", "chunked");
             } else if (!useGzipWhenAccepted()) {
-                pending = sendContentLengthHeaderIfNotAlreadyPresent(pw, pending);
+                // https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2
+                pending = wsHandshake ? 0 : sendContentLengthHeaderIfNotAlreadyPresent(pw, pending);
             }
             pw.append("\r\n");
             pw.flush();


### PR DESCRIPTION
According to [RFC7230 Section 3.3.2](https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2) 

"A server MUST NOT send a Content-Length header field in any response with a status code of 1xx (Informational) or 204 (No Content).  A server MUST NOT send a Content-Length header field in any 2xx (Successful) response to a CONNECT request (Section 4.3.6 of  [RFC7231])."