### PR TITLE
Set default charset to UTF-8

### DIFF
--- a/core/src/main/java/org/nanohttpd/protocols/http/NanoHTTPD.java
+++ b/core/src/main/java/org/nanohttpd/protocols/http/NanoHTTPD.java
@@ -478,7 +478,7 @@ public abstract class NanoHTTPD {
     public static String decodePercent(String str) {
         String decoded = null;
         try {
-            decoded = URLDecoder.decode(str, "UTF8");
+            decoded = URLDecoder.decode(str, "UTF-8");
         } catch (UnsupportedEncodingException ignored) {
             NanoHTTPD.LOG.log(Level.WARNING, "Encoding not supported, ignored", ignored);
         }

--- a/core/src/main/java/org/nanohttpd/protocols/http/content/ContentType.java
+++ b/core/src/main/java/org/nanohttpd/protocols/http/content/ContentType.java
@@ -38,7 +38,9 @@ import java.util.regex.Pattern;
 
 public class ContentType {
 
-    private static final String ASCII_ENCODING = "US-ASCII";
+    public static final String ASCII_ENCODING = "US-ASCII";
+
+    public static final String UTF8_ENCODING = "UTF-8";
 
     private static final String MULTIPART_FORM_DATA_HEADER = "multipart/form-data";
 
@@ -69,7 +71,7 @@ public class ContentType {
             encoding = getDetailFromContentHeader(contentTypeHeader, CHARSET_PATTERN, null, 2);
         } else {
             contentType = "";
-            encoding = "UTF-8";
+            encoding = UTF8_ENCODING;
         }
         if (MULTIPART_FORM_DATA_HEADER.equalsIgnoreCase(contentType)) {
             boundary = getDetailFromContentHeader(contentTypeHeader, BOUNDARY_PATTERN, null, 2);
@@ -92,7 +94,7 @@ public class ContentType {
     }
 
     public String getEncoding() {
-        return encoding == null ? ASCII_ENCODING : encoding;
+        return encoding == null ? UTF8_ENCODING : encoding;
     }
 
     public String getBoundary() {


### PR DESCRIPTION
When there is no charset specified in Content-Type, use UTF-8 by default instead of ASCII