### PR TITLE
fix error for getQueryParameterString

### DIFF
--- a/core/src/main/java/org/nanohttpd/protocols/http/HTTPSession.java
+++ b/core/src/main/java/org/nanohttpd/protocols/http/HTTPSession.java
@@ -157,6 +157,7 @@ public class HTTPSession implements IHTTPSession {
                 decodeParms(uri.substring(qmi + 1), parms);
                 uri = NanoHTTPD.decodePercent(uri.substring(0, qmi));
             } else {
+                queryParameterString = "";
                 uri = NanoHTTPD.decodePercent(uri);
             }
 


### PR DESCRIPTION
When this request has not any query string, but getQueryParameterString return query string of prev request. Because queryParameterString is not set blank. They are same HttpSession.