### PR TITLE
Fix non-deterministic behavior in testMultipartFormData

### DIFF
--- a/core/src/test/java/org/nanohttpd/junit/protocols/http/HttpServerTest.java
+++ b/core/src/test/java/org/nanohttpd/junit/protocols/http/HttpServerTest.java
@@ -49,6 +49,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.StringReader;
 import java.net.InetAddress;
+import java.util.Collections;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -230,7 +231,9 @@ public class HttpServerTest {
 
                     try {
                         session.parseBody(this.files);
-                        for (String key : files.keySet()) {
+                        List<String> keyList = new ArrayList<>(files.keySet());
+                        Collections.sort(keyList);
+                        for (String key : keyList) {
                             responseMsg.append(key);
                         }
                     } catch (Exception e) {


### PR DESCRIPTION
### Description 

I encountered non-deterministic behavior while running the following tests using NonDex:

core.src.test.java.org.nanohttpd.junit.protocols.http.HttpServerTest.testMultipartFormData

### Steps to reproduce

NonDex: https://github.com/TestingResearchIllinois/NonDex
Run the tests with NonDex: 

```
mvn -pl core edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.nanohttpd.junit.protocols.http.HttpServerTest#testMultipartFormData
```

The error message shows:

<details>
  <summary>Click to view</summary>


```
Running org.nanohttpd.junit.protocols.http.HttpServerTest
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.549 sec <<< FAILURE! - in org.nanohttpd.junit.protocols.http.HttpServerTest
testMultipartFormData(org.nanohttpd.junit.protocols.http.HttpServerTest)  Time elapsed: 0.548 sec  <<< FAILURE!
org.junit.ComparisonFailure: Server failed multi-part data parsecommentbin expected:<[bincomment]> but was:<[commentbin]>
	at org.junit.Assert.assertEquals(Assert.java:115)
	at org.nanohttpd.junit.protocols.http.HttpServerTest.testMultipartFormData(HttpServerTest.java:265)


Results :

Failed tests:
  HttpServerTest.testMultipartFormData:265 Server failed multi-part data parsecommentbin expected:<[bincomment]> but was:<[commentbin]>

Tests run: 1, Failures: 1, Errors: 0, Skipped: 0

INFO: Surefire failed when running tests for ushu+f2EpyqhU1Vs8NANOwdxqiB0jaCdmLz34a24Yc=
INFO: Adding excluded groups to newly created one
INFO: Creating new argline for Surefire
CONFIG: nondexFilter=.*
nondexMode=FULL
nondexSeed=974622
nondexStart=0
nondexEnd=9223372036854775807
nondexPrintstack=false
nondexDir=/Users/zhouzhanwang/Desktop/nanohttpd/core/.nondex
nondexJarDir=/Users/zhouzhanwang/Desktop/nanohttpd/core/.nondex
nondexExecid=twViEYQ2+WftkXILPlPC9xKbHbzOzznkmS0MN2crxEU=
nondexLogging=CONFIG
test=
[INFO] Surefire report directory: /Users/zhouzhanwang/Desktop/nanohttpd/core/.nondex/twViEYQ2+WftkXILPlPC9xKbHbzOzznkmS0MN2crxEU=
[INFO] parallel='none', perCoreThreadCount=true, threadCount=0, useUnlimitedThreads=false, threadCountSuites=0, threadCountClasses=0, threadCountMethods=0, parallelOptimized=true
```

</details>

### Potential Solution

The issue occurs due to non-deterministic behavior of function `public Response serve(IHTTPSession session)` in testMultipartFormData. The function iterates through the key set of `Map<String, String>` object `files` and then appends the keys to `StringBuilder` object `responseMsg`. However, the order of the key set of a Map object in Java is non-deterministic, which means the keys appended to `responseMsg` can be in any order. This causes the `String` variable `line` at line 266 to be either `"bincomment"` or `"commentbin"`, and thus `assertEquals` at line 268 could fail.

Here I propose a solution that may fix the issue. Before we iterate the key set of the map object, we can store all the keys in a `List<String>` object and sort the list. Now, the order of keys in the list becomes deterministic, and we can iterate through the list and append the keys to `responseMsg` in a deterministic order. In this way, `line` variable will always be `"bincomment"`, the same as the expected value.