### PR TITLE
Make ServerRunnable fields volatile for thread safety

### DIFF
--- a/core/src/main/java/org/nanohttpd/protocols/http/NanoHTTPD.java
+++ b/core/src/main/java/org/nanohttpd/protocols/http/NanoHTTPD.java
@@ -609,10 +609,8 @@ public abstract class NanoHTTPD {
         while (!serverRunnable.hasBinded() && serverRunnable.getBindException() == null) {
             try {
                 Thread.sleep(10L);
-            } catch (Throwable e) {
-                // on android this may not be allowed, that's why we
-                // catch throwable the wait should be very short because we are
-                // just waiting for the bind of the socket
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt(); // re-interrupt
             }
         }
         if (serverRunnable.getBindException() != null) {

--- a/core/src/main/java/org/nanohttpd/protocols/http/NanoHTTPD.java
+++ b/core/src/main/java/org/nanohttpd/protocols/http/NanoHTTPD.java
@@ -609,8 +609,10 @@ public abstract class NanoHTTPD {
         while (!serverRunnable.hasBinded() && serverRunnable.getBindException() == null) {
             try {
                 Thread.sleep(10L);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt(); // re-interrupt
+            } catch (Throwable e) {
+                // on android this may not be allowed, that's why we
+                // catch throwable the wait should be very short because we are
+                // just waiting for the bind of the socket
             }
         }
         if (serverRunnable.getBindException() != null) {

--- a/core/src/main/java/org/nanohttpd/protocols/http/ServerRunnable.java
+++ b/core/src/main/java/org/nanohttpd/protocols/http/ServerRunnable.java
@@ -44,13 +44,13 @@ import java.util.logging.Level;
  */
 public class ServerRunnable implements Runnable {
 
-    private NanoHTTPD httpd;
+    private final NanoHTTPD httpd;
 
     private final int timeout;
 
-    private IOException bindException;
+    private volatile IOException bindException;
 
-    private boolean hasBinded = false;
+    private volatile boolean hasBinded = false;
 
     public ServerRunnable(NanoHTTPD httpd, int timeout) {
         this.httpd = httpd;


### PR DESCRIPTION
NanoHTTPD.java's `start(final int timeout, boolean daemon)` method uses inter-thread communication to signal the status of the daemon thread. Section 17.3 of the [Java Lang Specification](https://docs.oracle.com/javase/specs/jls/se8/html/jls-17.html#jls-17.3) states that Thread.sleep has no synchronization semantics, so the compiler does not have to reload values cached in registers after a call to Thread.sleep. This means that the while loop in start() might never terminate, even if the other thread changed the status.

Changing the variables to volatile would require Java to reload the values after each cycle.