### PR TITLE
Fix typo in NanoHTTPD.java

### DIFF
--- a/core/src/main/java/org/nanohttpd/protocols/http/NanoHTTPD.java
+++ b/core/src/main/java/org/nanohttpd/protocols/http/NanoHTTPD.java
@@ -412,7 +412,7 @@ public abstract class NanoHTTPD {
      * provide a subclass of the ServerRunnable.
      * 
      * @param timeout
-     *            the socet timeout to use.
+     *            the socket timeout to use.
      * @return the server runnable.
      */
     protected ServerRunnable createServerRunnable(final int timeout) {


### PR DESCRIPTION
Replaces 'socet' with 'socket' on line 415.